### PR TITLE
Fix Universal Viewer and IIIF

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,8 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -182,8 +182,8 @@ Hyrax.config do |config|
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately
-  #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
-  #  config.cache_path = ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
+  config.upload_path = ->() { Pathname.new(ENV['UPLOAD_PATH'] || '/opt/uploads') }
+  config.cache_path = ->() { Pathname.new(ENV['CACHE_PATH'] || '/opt/uploads/cache') }
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
@@ -199,7 +199,7 @@ Hyrax.config do |config|
   # Location on local file system where uploaded files will be staged
   # prior to being ingested into the repository or having derivatives generated.
   # If you use a multi-server architecture, this MUST be a shared volume.
-  # config.working_path = Rails.root.join( 'tmp', 'uploads')
+  config.working_path = ENV['WORKING_PATH'] || '/opt/uploads'
 
   # Should the media display partial render a download link?
   # config.display_media_download_link = true


### PR DESCRIPTION
I followed the troubleshooting guide at
https://samvera.github.io/troubleshooting_riiif.html

Fix upload, cache, and working path:
These should be configurable with
environment variables and should
default to a directory outside of
a specific deploy.

Serve static files

Fixes #16 