### PR TITLE
Cleanup after specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
+  gem 'database_cleaner'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
     connection_pool (2.2.2)
     crass (1.0.4)
     daemons (1.2.6)
+    database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deprecation (1.0.0)
@@ -814,6 +815,7 @@ DEPENDENCIES
   capistrano-sidekiq (~> 0.20.0)
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  database_cleaner
   devise
   devise-guests (~> 0.6)
   dotenv-rails (~> 2.2.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'database_cleaner'
+require 'active_fedora/cleaner'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -28,6 +31,17 @@ require 'rspec/rails'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveJob::Base.queue_adapter = :test
+    ActiveFedora::Cleaner.clean!
+    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.start
+  end
+
+  config.before(clean: true) do
+    ActiveFedora::Cleaner.clean!
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
Use `DatabaseCleaner` and `ActiveFedora::Cleaner` to manage RDBMS, Fedora, and Solr state in the test suite.