### PR TITLE
Ensure derivatives persist between deploys

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -187,7 +187,7 @@ Hyrax.config do |config|
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
-  config.derivatives_path = ENV['DERIVATIVES_PATH'] || Rails.root.join('tmp', 'derivatives')
+  config.derivatives_path = ENV['DERIVATIVES_PATH'] || '/opt/derivatives'
 
   # Should schema.org microdata be displayed?
   # config.display_microdata = true


### PR DESCRIPTION
Set the default derivative location to
/opt/derivatives so that thumbnails
don't disappear every time we make
a new release.

Fixes #51 
Fixes #54