### PR TITLE
Parameterize fedora and solr dev configs

### DIFF
--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,7 +1,7 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8080 %>/rest
+  url: <%= ENV['FEDORA_DEVELOPMENT_URL'] || "http://127.0.0.1:8984/rest" %>
   base_path: /dev
 test:
   user: fedoraAdmin

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,6 +1,6 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8983 %>/solr/hydra-development
+  url: <%= ENV['SOLR_DEVELOPMENT_URL'] || "http://127.0.0.01:8983/solr/hydra-development" %>
 test:
   url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
 production:


### PR DESCRIPTION
Adding FEDORA_DEVELOPMENT_URL and SOLR_DEVELOPMENT_URL ENV variables.
Changing the default Fedora port back to the 8984 that DCE prefers (the VM will use the ENV vars).