### PR TITLE
Fix Blacklight dev config

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,6 +1,6 @@
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
+  url: <%= ENV['SOLR_DEVELOPMENT_URL'] || "http://127.0.0.01:8983/solr/hydra-development" %>
 test: &test
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>


### PR DESCRIPTION
We updated the solr.yml to use SOLR_DEVELOPMENT_URL but missed doing the same for Blacklight. This commits brings the two in sync.