### PR TITLE
Finish basic setup for CSV importer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ Metrics/BlockLength:
     - 'config/**/*'
     - 'spec/**/*'
 
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/tasks/**/*'
+
 RSpec/ExampleLength:
   Enabled: true
   Exclude:

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -10,7 +10,11 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   DELIMITER = '|~|'
 
   def fields
-    CALIFORNICA_TERMS_MAP.keys
+    CALIFORNICA_TERMS_MAP.keys + [:visibility]
+  end
+
+  def visibility
+    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
   end
 
   def map_field(name)

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe CalifornicaMapper do
   it "maps the required identifier field" do
     expect(mapper.map_field(:identifier)).to contain_exactly('21198/zz0002nq4w')
   end
+
+  it "maps visibility to open" do
+    expect(mapper.visibility)
+      .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  end
+
+  describe '#fields' do
+    it 'has expected fields' do
+      expect(mapper.fields).to include(:title, :identifier, :visibility)
+    end
+  end
 end

--- a/spec/tasks/ingest_spec.rb
+++ b/spec/tasks/ingest_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'californica:ingest:csv' do
+  subject(:task)  { rake[task_name] }
+  let(:csv_path)  { 'spec/fixtures/example.csv' }
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { 'lib/tasks/ingest' }
+
+  def loaded_files_excluding_current_rake_file
+    $LOADED_FEATURES.reject { |f| f == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+    Rake::Task.define_task(:environment)
+  end
+
+  context 'after sucessful task run' do
+    before { task.invoke(csv_path) }
+
+    let(:created_work) { Work.where(identifier_tesim: '21198/zz0002nq4w').first }
+
+    it 'has created a work with the correct title' do
+      title = "Protesters with signs in gallery of Los Angeles County Supervisors " \
+              "hearing over eminent domain for construction of Harbor Freeway, Calif., 1947"
+
+      expect(created_work.title).to contain_exactly(title)
+    end
+  end
+end

--- a/spec/tasks/ingest_spec.rb
+++ b/spec/tasks/ingest_spec.rb
@@ -30,5 +30,10 @@ RSpec.describe 'californica:ingest:csv' do
 
       expect(created_work.title).to contain_exactly(title)
     end
+
+    it 'has created a public work' do
+      expect(created_work.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
   end
 end


### PR DESCRIPTION
Sets works imported via the CSV parser to PUBLIC/"open" by default.

Adds an integration test checking that the CSV importer rake task is working as
expected. We setup the task and use `example.csv` to ensure it runs on a healthy
example and maps the title as expected.

Connected to #78.