### PR TITLE
Enable deloyment via the UCLA Jump Server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@ DATABASE_ADAPTER=postgresql
 # DATABASE_NAME=californica_development
 # DATABASE_NAME=californica_test
 
+CABLE_CHANNEL_PREFIX=californica_development
 DATABASE_HOST=localhost
 DATABASE_USERNAME=californica
 DATABASE_PASSWORD=californica
@@ -16,5 +17,8 @@ FEDORA_PASSWORD=fedoraAdmin
 FEDORA_URL=http://127.0.0.1:8984/rest
 GEONAMES_USERNAME=
 RAILS_SERVE_STATIC_FILES=true
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_CABLE_DB=1
 SIDEKIQ_WORKERS=7
 SOLR_URL=http://127.0.0.1:8983/solr/californica

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ jdk:
 - oraclejdk8
 rvm:
 - 2.5
+env:
+- DATABASE_USERNAME=travis
 before_script:
 - bundle exec rake db:create
 script:
 - bundle exec rake
 services:
 - redis-server
-- postgresql
+- mysql
 after_success:
 - |
   if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ gem 'honeybadger', '~> 3.1'
 gem 'hyrax', '~> 2.1.0'
 gem 'rails', '~> 5.1.6'
 
-# Use postgresql
-gem 'pg', '~> 1.0'
+# Use mysql
+gem 'mysql2', '~> 0.5'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'honeybadger', '~> 3.1'
 gem 'hyrax', '~> 2.1.0'
 gem 'rails', '~> 5.1.6'
 
+gem 'pkg-config', '~> 1.1'
+
 # Use mysql
 gem 'mysql2', '~> 0.5'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -498,6 +498,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mysql2 (0.5.2)
     nest (3.1.1)
       redic
     net-http-persistent (3.0.0)
@@ -533,7 +534,6 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
-    pg (1.0.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.2)
@@ -836,7 +836,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
-  pg (~> 1.0)
+  mysql2 (~> 0.5)
   puma (~> 3.7)
   rails (~> 5.1.6)
   riiif (~> 1.1)
@@ -854,7 +854,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.4.0p0
 
 BUNDLED WITH
    1.16.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,6 +534,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
+    pkg-config (1.3.1)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.2)
@@ -837,6 +838,7 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   mysql2 (~> 0.5)
+  pkg-config (~> 1.1)
   puma (~> 3.7)
   rails (~> 5.1.6)
   riiif (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Development
 
 Requirements:
 1. Ruby and Bundler
-1. Postgres, Redis, Node.js, and Java
+1. MySQL (or MariaDB), Redis, Node.js, and Java
 1. Various build tools (Ubuntu packages are listed below - not sure about other
    distros...)
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
-  channel_prefix: tenjeo_production
+  url: redis://<%= ENV['REDIS_HOST'] %>:<%= ENV['REDIS_PORT'] %>/<%= ENV['REDIS_CABLE_DB'] %>
+  channel_prefix: <%= ENV['CABLE_CHANNEL_PREFIX'] || 'californica_production' %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,10 +18,9 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  username: <%= ENV['DATABASE_USERNAME'] %>
   database: <%= ENV['DATABASE_NAME'] || 'californica_test' %>
 
 production:
   <<: *default
-  adapter:  'postgresql'
   database: <%= ENV['DATABASE_NAME'] %>
+  pool:     <%= ENV['DATABASE_POOL'] || 20 %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,5 @@
 default: &default
-  adapter:      <%= ENV['DATABASE_ADAPTER'] || 'postgresql' %>
-  encoding:     unicode
+  adapter:      <%= ENV['DATABASE_ADAPTER'] || 'mysql2' %>
   pool:         <%= ENV['DATABASE_POOL'] || 5 %>
   timeout:      5000
   host:         <%= ENV['DATABASE_HOST'] || 'localhost' %>
@@ -22,5 +21,6 @@ test:
 
 production:
   <<: *default
+  adapter:  'mysql2'
   database: <%= ENV['DATABASE_NAME'] %>
   pool:     <%= ENV['DATABASE_POOL'] || 20 %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -64,7 +64,7 @@ after 'deploy:published', 'rails:rake:db:seed'
 namespace :deploy do
   after :finishing, :restart_apache do
     on roles(:app) do
-      execute :sudo, :systemctl, :restart, :apache2
+      execute :sudo, :systemctl, :restart, :httpd
     end
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,6 +7,24 @@ set :repo_url, "https://github.com/UCLALibrary/californica.git"
 
 set :deploy_to, '/opt/californica'
 set :rails_env, 'production'
+
+if ENV['VIA_JUMP']
+  require 'net/ssh/proxy/command'
+
+  # Define the hostanme of the server to tunnel through
+  jump_host = ENV['JUMP_HOST'] || 'jump.library.ucla.edu'
+
+  # Define the port number of the jump host
+  jump_port = ENV['JUMP_PORT'] || '31926'
+
+  # Define the username for tunneling
+  jump_user = ENV['JUMP_USER'] || ENV['USER']
+
+  # Configure Capistrano to use the jump host as a proxy
+  ssh_command = "ssh -p #{jump_port} #{jump_user}@#{jump_host} -W %h:%p"
+  set :ssh_options, proxy: Net::SSH::Proxy::Command.new(ssh_command)
+end
+
 set :ssh_options, keys: ["ucla_deploy_rsa"] if File.exist?("ucla_deploy_rsa")
 
 set :log_level, :debug

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,6 +12,8 @@ set :ssh_options, keys: ["ucla_deploy_rsa"] if File.exist?("ucla_deploy_rsa")
 set :log_level, :debug
 set :bundle_flags, '--deployment'
 
+set :default_env, 'PASSENGER_INSTANCE_REGISTRY_DIR' => '/var/run'
+
 set :keep_releases, 5
 set :assets_prefix, "#{shared_path}/public/assets"
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :repo_url, "https://github.com/UCLALibrary/californica.git"
 set :deploy_to, '/opt/californica'
 set :rails_env, 'production'
 
-if ENV['VIA_JUMP']
+if ENV['VIA_JUMP'] == "yes"
   require 'net/ssh/proxy/command'
 
   # Define the hostanme of the server to tunnel through

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,6 @@ set :ssh_options, keys: ["ucla_deploy_rsa"] if File.exist?("ucla_deploy_rsa")
 
 set :log_level, :debug
 set :bundle_flags, '--deployment'
-set :bundle_env_variables, nokogiri_use_system_libraries: 1
 
 set :keep_releases, 5
 set :assets_prefix, "#{shared_path}/public/assets"

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -13,6 +13,7 @@ test:
   base_path: <%= ENV['FEDORA_BASE_PATH'] || '/test' %>
 
 production:
-  <<: *default
-  url: <%= ENV['FEDORA_URL'] || 'http://127.0.0.1:8080/rest' %>
+  user: <%= ENV['FEDORA_USER'] %>
+  password: <%= ENV['FEDORA_PASSWORD'] %>
+  url: <%= ENV['FEDORA_URL'] %>
   base_path: <%= ENV['FEDORA_BASE_PATH'] || '/prod' %>

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -5,5 +5,5 @@ test:
   host: localhost
   port: 6379
 production:
-  host: localhost
-  port: 6379
+  host: <%= ENV['REDIS_HOST'] %>
+  port: <%= ENV['REDIS_PORT'] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,10 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20180604004616) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "bookmarks", id: :serial, force: :cascade do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -27,7 +24,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "checksum_audit_logs", force: :cascade do |t|
+  create_table "checksum_audit_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -40,7 +37,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "collection_branding_infos", force: :cascade do |t|
+  create_table "collection_branding_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "collection_id"
     t.string "role"
     t.string "local_path"
@@ -52,7 +49,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "collection_type_participants", force: :cascade do |t|
+  create_table "collection_type_participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -62,7 +59,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade do |t|
+  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -70,7 +67,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade do |t|
+  create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
@@ -91,7 +88,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade do |t|
+  create_table "featured_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -100,7 +97,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade do |t|
+  create_table "file_download_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -111,7 +108,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade do |t|
+  create_table "file_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -122,7 +119,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_collection_types", force: :cascade do |t|
+  create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.text "description"
     t.string "machine_id"
@@ -139,14 +136,14 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade do |t|
+  create_table "hyrax_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "job_io_wrappers", force: :cascade do |t|
+  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "user_id"
     t.bigint "uploaded_file_id"
     t.string "file_set_id"
@@ -160,7 +157,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", id: :serial, force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -168,13 +165,13 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", id: :serial, force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", id: :serial, force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -197,7 +194,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", id: :serial, force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -214,7 +211,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", id: :serial, force: :cascade do |t|
+  create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
@@ -225,7 +222,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade do |t|
+  create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -236,7 +233,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["permission_template_id"], name: "index_permission_template_accesses_on_permission_template_id"
   end
 
-  create_table "permission_templates", force: :cascade do |t|
+  create_table "permission_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at", null: false
@@ -246,7 +243,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade do |t|
+  create_table "proxy_deposit_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "work_id", null: false
     t.bigint "sending_user_id", null: false
     t.bigint "receiving_user_id", null: false
@@ -260,7 +257,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade do |t|
+  create_table "proxy_deposit_rights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "grantor_id"
     t.bigint "grantee_id"
     t.datetime "created_at", null: false
@@ -269,14 +266,14 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
   end
 
-  create_table "qa_local_authorities", force: :cascade do |t|
+  create_table "qa_local_authorities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
-  create_table "qa_local_authority_entries", force: :cascade do |t|
+  create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
@@ -286,11 +283,11 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "roles", id: :serial, force: :cascade do |t|
+  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
   end
 
-  create_table "roles_users", id: false, force: :cascade do |t|
+  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "role_id"
     t.integer "user_id"
     t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
@@ -299,7 +296,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "searches", id: :serial, force: :cascade do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -308,7 +305,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade do |t|
+  create_table "single_use_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -317,7 +314,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade do |t|
+  create_table "sipity_agents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -325,7 +322,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade do |t|
+  create_table "sipity_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -336,7 +333,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade do |t|
+  create_table "sipity_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -347,7 +344,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
+  create_table "sipity_entity_specific_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -359,7 +356,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade do |t|
+  create_table "sipity_notifiable_contexts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -372,7 +369,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade do |t|
+  create_table "sipity_notification_recipients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -384,7 +381,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade do |t|
+  create_table "sipity_notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -393,7 +390,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade do |t|
+  create_table "sipity_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -401,7 +398,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade do |t|
+  create_table "sipity_workflow_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -412,7 +409,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade do |t|
+  create_table "sipity_workflow_methods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -421,7 +418,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
+  create_table "sipity_workflow_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -429,7 +426,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade do |t|
+  create_table "sipity_workflow_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -437,7 +434,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
+  create_table "sipity_workflow_state_action_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -445,7 +442,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade do |t|
+  create_table "sipity_workflow_state_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -453,7 +450,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade do |t|
+  create_table "sipity_workflow_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -462,7 +459,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade do |t|
+  create_table "sipity_workflows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -474,20 +471,20 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade do |t|
+  create_table "tinymce_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade do |t|
+  create_table "trophies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade do |t|
+  create_table "uploaded_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "file"
     t.bigint "user_id"
     t.string "file_set_uri"
@@ -497,7 +494,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade do |t|
+  create_table "user_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -508,7 +505,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -550,7 +547,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade do |t|
+  create_table "version_committers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -559,7 +556,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade do |t|
+  create_table "work_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 # Set up a default admin user
 u = User.find_or_create_by(email: 'admin@example.com')
 u.display_name = "Default Admin"
-u.password = ENV['ADMIN_PASSWORD']
+u.password = ENV['ADMIN_PASSWORD'] || 'password'
 u.save
 admin_role = Role.find_or_create_by(name: 'admin')
 admin_role.users << u


### PR DESCRIPTION
The purpose of this branch is to introduce configuration in the `deploy.rb` file to allow deployment of code via the UCLA bastion host (`jump.library.ucla.edu`). 

This allows us to maintain secure server environments - keeping firewall access in place to limit direct access to our servers. 

This configuration creates a new environment variable `VIA_JUMP` that allows the entity deploying the code to set whether or not code is deployed through the jump server or directly to the server environment. 