### PR TITLE
Add `Work#genre` attribute implementation

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -12,6 +12,8 @@ class Work < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :genre, predicate: ::RDF::Vocab::EDM.hasType
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -8,9 +8,7 @@ class Work < ActiveFedora::Base
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
-  property :genre, predicate: 'http://purl.org/dc/elements/1.1/type' do |index|
-    index.as :stored_searchable
-  end
+
   property :extent, predicate: 'http://purl.org/dc/elements/1.1/format' do |index|
     index.as :stored_searchable
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
-# Generated via
-#  `rails generate hyrax:work Work`
+
 class Work < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -2,6 +2,24 @@
 require 'rails_helper'
 
 RSpec.describe Work do
+  subject(:work) { described_class.new }
+
+  describe '#genre' do
+    let(:values) { ['SciFi'] }
+
+    it 'can set a genre' do
+      expect { work.genre = values }
+        .to change { work.genre.to_a }
+        .to contain_exactly(*values)
+    end
+
+    it 'sets to edm:hasType' do
+      expect { work.genre = values }
+        .to change { work.resource.predicates }
+        .to include RDF::Vocab::EDM.hasType
+    end
+  end
+
   it "has extent" do
     work = described_class.new
     work.extent = ['1 photograph']

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-# Generated via
-#  `rails generate hyrax:work Work`
 require 'rails_helper'
 
 RSpec.describe Work do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -4,12 +4,6 @@
 require 'rails_helper'
 
 RSpec.describe Work do
-  it "has genre" do
-    work = described_class.new
-    work.genre = ['SciFi']
-    expect(work.genre).to include 'SciFi'
-    expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/type/)
-  end
   it "has extent" do
     work = described_class.new
     work.extent = ['1 photograph']


### PR DESCRIPTION
Implement a Genre term using the Europeana Data Model (EDM).

Using the RDF::Vocab::EDM module (from the `rdf-vocab` gem) makes the URI-ref easier to maintain.

Closes #64.

Replaces #112 