### PR TITLE
Enable deployment via the UCLA Jump Server

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,6 +7,24 @@ set :repo_url, "https://github.com/UCLALibrary/californica.git"
 
 set :deploy_to, '/opt/californica'
 set :rails_env, 'production'
+
+if ENV['VIA_JUMP']
+  require 'net/ssh/proxy/command'
+
+  # Define the hostanme of the server to tunnel through
+  jump_host = ENV['JUMP_HOST'] || 'jump.library.ucla.edu'
+
+  # Define the port number of the jump host
+  jump_port = ENV['JUMP_PORT'] || '31926'
+
+  # Define the username for tunneling
+  jump_user = ENV['JUMP_USER'] || ENV['USER']
+
+  # Configure Capistrano to use the jump host as a proxy
+  ssh_command = "ssh -p #{jump_port} #{jump_user}@#{jump_host} -W %h:%p"
+  set :ssh_options, proxy: Net::SSH::Proxy::Command.new(ssh_command)
+end
+
 set :ssh_options, keys: ["ucla_deploy_rsa"] if File.exist?("ucla_deploy_rsa")
 
 set :log_level, :debug

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :repo_url, "https://github.com/UCLALibrary/californica.git"
 set :deploy_to, '/opt/californica'
 set :rails_env, 'production'
 
-if ENV['VIA_JUMP']
+if ENV['VIA_JUMP'] == "yes"
   require 'net/ssh/proxy/command'
 
   # Define the hostanme of the server to tunnel through


### PR DESCRIPTION
The purpose of this branch is to introduce configuration in the `deploy.rb` file to allow deployment of code via the UCLA bastion host (`jump.library.ucla.edu`). 

This allows us to maintain secure server environments - keeping firewall access in place to limit direct access to our servers. 

This configuration creates a new environment variable `VIA_JUMP` that allows the entity deploying the code to set whether or not code is deployed through the jump server or directly to the server environment. 

Supersedes #113 