### PR TITLE
Change all references to tenejo to californica.

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -30,7 +30,7 @@
   background: $ucla-blue;
 }
 
-#tenejo-institution_name {
+#californica-institution_name {
   font-family: TimesNewRoman,"Times New Roman",Times,Baskerville,Georgia,serif;
   font-weight: bold;
   letter-spacing: 2px;

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -5,6 +5,6 @@ module HyraxHelper
   include Hyrax::HyraxHelperBehavior
 
   def application_name
-    t('tenejo.application_name', default: super)
+    t('californica.application_name', default: super)
   end
 end

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,4 +1,4 @@
 <a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
   <span class="brand-logo"><%= image_tag("ucla-library-logo.png") %></span>
-  <span id="tenejo-institution_name"><%= t('tenejo.institution_name') %></span>
+  <span id="californica-institution_name"><%= t('californica.institution_name') %></span>
 </a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Tenjeo</title>
+    <title>Californica</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="navbar-right">
       <div class="navbar-text text-right">
-        <p><%= t('tenejo.product_name') %> <span title="<%= GIT_SHA %>"><%= DEPLOYED_VERSION %>; <%= LAST_DEPLOYED %></span></p>
+        <p><%= t('californica.product_name') %> <span title="<%= GIT_SHA %>"><%= DEPLOYED_VERSION %>; <%= LAST_DEPLOYED %></span></p>
         <p><%= t('hyrax.footer.copyright_html') %></p>
       </div>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Tenjeo
+module Californica
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "tenjeo_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "californica_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/locales/californica.en.yml
+++ b/config/locales/californica.en.yml
@@ -1,6 +1,6 @@
 ---
 en:
-  tenejo:
+  californica:
     application_name: Samvera
-    product_name: Tenejo
+    product_name: Californica
     institution_name: Samvera

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tenjeo",
+  "name": "californica",
   "private": true,
   "dependencies": {}
 }


### PR DESCRIPTION
Changing all references to tenejo to californica, should address the
lingering referneces to Tenejo in the web UI. Connected to #99.