### PR TITLE
Remove copyright statement from footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
     <div class="navbar-right">
       <div class="navbar-text text-right">
         <p><%= t('californica.product_name') %> <span title="<%= GIT_SHA %>"><%= DEPLOYED_VERSION %>; <%= LAST_DEPLOYED %></span></p>
-        <p><%= t('hyrax.footer.copyright_html') %></p>
+        <p><%= t('californica.footer.copyright_html') %></p>
       </div>
     </div>
   </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="navbar navbar-inverse site-footer">
   <div class="container-fluid">
     <div class="navbar-text text-left">
-        <p><%= t('hyrax.footer.service_html') %></p>
+        <p><%= t('californica.footer.service_html') %></p>
         <p><%= t('hyrax.product_name') %> v<%= Hyrax::VERSION %></p>
     </div>
     <div class="navbar-right">

--- a/config/locales/californica.en.yml
+++ b/config/locales/californica.en.yml
@@ -4,3 +4,6 @@ en:
     application_name: Samvera
     product_name: Californica
     institution_name: Samvera
+    footer:
+      copyright_html: ""
+      service_html: Powered by <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.


### PR DESCRIPTION
create californica.footer.copyright_html translation for future use,
leave it blank for now
connects to #126 