### PR TITLE
Add repository field to Work

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -52,6 +52,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('publisher', :facetable), limit: 5
     config.add_facet_field solr_name('file_format', :facetable), limit: 5
     config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
+    config.add_facet_field solr_name('repository', :facetable), limit: 5
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
@@ -105,6 +106,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('resource_type', :stored_searchable), label: 'Resource Type'
     config.add_show_field solr_name('format', :stored_searchable)
     config.add_show_field solr_name('identifier', :stored_searchable)
+    config.add_show_field solr_name('repository', :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/models/schemas/generated_resource_schema_strategy.rb
+++ b/app/models/schemas/generated_resource_schema_strategy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Schemas
+  ##
+  # An extension strategy to apply schema changes to the underlying AT model if it
+  # has already been generated.
+  class GeneratedResourceSchemaStrategy < ActiveFedora::SchemaIndexingStrategy
+    ##
+    # @see SchemaIndexingStrategy#apply
+    def apply(object, property)
+      result = super
+
+      klass = object.instance_variable_get(:@generated_resource_class)
+      return result unless klass
+      klass.property property.name, property.to_h
+      result
+    end
+  end
+end

--- a/app/models/schemas/work_metadata.rb
+++ b/app/models/schemas/work_metadata.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module Schemas
+  class WorkMetadata < ActiveTriples::Schema
+    property :repository, predicate: RDF::Vocab::MODS.locationCopySublocation
+  end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -14,6 +14,8 @@ class Work < ActiveFedora::Base
 
   property :genre, predicate: ::RDF::Vocab::EDM.hasType
 
+  apply_schema Schemas::WorkMetadata, Schemas::GeneratedResourceSchemaStrategy.new
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,11 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+    search:
+      fields:
+        facet:
+          repository_sim: 'Repository'
+        index:
+          repository_sim: 'Repository'
+        show:
+          repository_sim: 'Repository'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,4 @@
+simple_form:
+  labels:
+    defaults:
+      repository: 'Repository'

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -26,4 +26,11 @@ RSpec.describe Work do
     expect(work.extent).to include '1 photograph'
     expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/format/)
   end
+
+  it "has repository" do
+    work = described_class.new
+    work.repository = ['a repository']
+    expect(work.repository).to include 'a repository'
+    expect(work.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#locationCopySublocation/)
+  end
 end


### PR DESCRIPTION
This commit adds the repository field to the work
with the `modsrdf:locationCopySubLocation` predicate.

This commit introduces the `WorkMetadata` schema class
which is part of a pattern used in Mahonia:

https://github.com/curationexperts/mahonia

Connected to #100