### PR TITLE
Automate daily re-indexing of news negatives

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -29,3 +29,8 @@ end
 every :day, at: '1:00am' do
   command "/usr/bin/find /tmp -type f -mtime +7 -user deploy -execdir /bin/rm -- {} \\;"
 end
+
+# Reindex news negatives collection daily
+every :day, at: '1:00am' do
+  rake "californica:ingest:reindex"
+end

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+CSV_FILE = '/opt/data/sample_data_set_la_daily_news/dlcs-ladnn-2018-09-06.csv'
 
 namespace :californica do
   namespace :ingest do
@@ -14,6 +15,18 @@ namespace :californica do
       parser = CalifornicaCsvParser.for(file: File.open(args[:filename]))
 
       Darlingtonia::Importer.new(parser: parser).import if parser.validate
+    end
+
+    desc "Reindex #{CSV_FILE}"
+    task :reindex do
+      if File.exist?(CSV_FILE)
+        require 'active_fedora/cleaner'
+        ActiveFedora::Cleaner.clean!
+        parser = CalifornicaCsvParser.for(file: File.open(CSV_FILE))
+        Darlingtonia::Importer.new(parser: parser).import if parser.validate
+      else
+        puts "Cannot find expected input file #{CSV_FILE}"
+      end
     end
   end
 end


### PR DESCRIPTION
Connected to #133 

I realize there are improvements we want to make here, like this CSV file should be an environment variable. However, I'd really like to get this in asap so the branch doesn't get stale and we can start testing a complete re-index against the latest indexing code. Right now a complete re-index is failing on the DCE RHEL box b/c fedora is falling over. I'd like to get that solved asap.