### PR TITLE
Add named_subject to model

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -54,6 +54,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
     config.add_facet_field solr_name('repository', :facetable), limit: 5
     config.add_facet_field solr_name('normalized_date', :facetable), limit: 5
+    config.add_facet_field solr_name('named_subject', :facetable), limit: 5
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
@@ -109,6 +110,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('identifier', :stored_searchable)
     config.add_show_field solr_name('repository', :stored_searchable)
     config.add_show_field solr_name('normalized_date', :stored_searchable)
+    config.add_show_field solr_name('named_subject', :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -12,13 +12,14 @@ class Work < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :local_identifier, predicate: ::RDF::Vocab::DC11.identifier
   property :funding_note, predicate: ::RDF::URI.intern('http://bibfra.me/vocab/marc/fundingInformation/')
   property :genre, predicate: ::RDF::Vocab::EDM.hasType
+  property :latitude, predicate: ::RDF::Vocab::EXIF.gpsLatitude
+  property :local_identifier, predicate: ::RDF::Vocab::DC11.identifier
+  property :longitude, predicate: ::RDF::Vocab::EXIF.gpsLongitude
+  property :named_subject, predicate: ::RDF::Vocab::MODS.subjectName
   property :normalized_date, predicate: ::RDF::Vocab::DC11.date
   property :repository, predicate: ::RDF::Vocab::MODS.locationCopySublocation
-  property :latitude, predicate: ::RDF::Vocab::EXIF.gpsLatitude
-  property :longitude, predicate: ::RDF::Vocab::EXIF.gpsLongitude
 
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -4,11 +4,14 @@ en:
     search:
       fields:
         facet:
+          named_subject: 'Name (subject)'
           repository_sim: 'Repository'
           normalized_date_sim: 'Date'
         index:
+          named_subject: 'Name (subject)'
           repository_sim: 'Repository'
           normalized_date_sim: 'Date'
         show:
+          named_subject: 'Name (subject)'
           repository_sim: 'Repository'
           normalized_date_sim: 'Date'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,7 +1,8 @@
 simple_form:
   labels:
     defaults:
-      repository: 'Repository'
-      normalized_date: 'Date'
-      local_identifier: 'Local Identifier'
       funding_note: 'Funding Note'
+      local_identifier: 'Local Identifier'
+      named_subject: 'Name (Subject)'
+      normalized_date: 'Date'
+      repository: 'Repository'

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -61,4 +61,10 @@ RSpec.describe Work do
     expect(work.longitude).to include '-94'
     expect(work.resource.dump(:ttl)).to match(/w3.org\/2003\/12\/exif\/ns#gpsLongitude/)
   end
+
+  it "has named subject" do
+    work.named_subject = ['Person, A']
+    expect(work.named_subject).to include 'Person, A'
+    expect(work.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#subjectName/)
+  end
 end


### PR DESCRIPTION
This commit adds the named_subject term
to the model and sets the correct label in the
simple_form locale.

It also sets up the faceting and searching
of the term as specified in the issue via the
catalog_controller.

Connected to #139