### PR TITLE
This commit adds the rights_country term

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -55,6 +55,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('repository', :facetable), limit: 5
     config.add_facet_field solr_name('normalized_date', :facetable), limit: 5
     config.add_facet_field solr_name('named_subject', :facetable), limit: 5
+    config.add_facet_field solr_name('rights_country', :facetable), limit: 5
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile
@@ -111,6 +112,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('repository', :stored_searchable)
     config.add_show_field solr_name('normalized_date', :stored_searchable)
     config.add_show_field solr_name('named_subject', :stored_searchable)
+    config.add_show_field solr_name('rights_country', :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -20,6 +20,7 @@ class Work < ActiveFedora::Base
   property :named_subject, predicate: ::RDF::Vocab::MODS.subjectName
   property :normalized_date, predicate: ::RDF::Vocab::DC11.date
   property :repository, predicate: ::RDF::Vocab::MODS.locationCopySublocation
+  property :rights_country, predicate: ::RDF::Vocab::EBUCore.rightsType
 
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -7,11 +7,14 @@ en:
           named_subject: 'Name (subject)'
           repository_sim: 'Repository'
           normalized_date_sim: 'Date'
+          rights_country: 'Rights (country of creation)'
         index:
           named_subject: 'Name (subject)'
           repository_sim: 'Repository'
           normalized_date_sim: 'Date'
+          rights_country: 'Rights (country of creation)'
         show:
           named_subject: 'Name (subject)'
           repository_sim: 'Repository'
           normalized_date_sim: 'Date'
+          rights_country: 'Rights (country of creation)'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -6,3 +6,4 @@ simple_form:
       named_subject: 'Name (Subject)'
       normalized_date: 'Date'
       repository: 'Repository'
+      rights_country: 'Rights (country of creation)'

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -67,4 +67,10 @@ RSpec.describe Work do
     expect(work.named_subject).to include 'Person, A'
     expect(work.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#subjectName/)
   end
+
+  it "rights country" do
+    work.rights_country = ['rights_country']
+    expect(work.rights_country).to include 'rights_country'
+    expect(work.resource.dump(:ttl)).to match(/ebu.ch\/metadata\/ontologies\/ebucore\/ebucore#rightsType/)
+  end
 end


### PR DESCRIPTION
to the model and sets the correct label in the
simple_form locale.

It also sets up the faceting and searching
of the term as specified in the issue via the
catalog_controller.

Connected to #142