### PR TITLE
Add latitude and longitude to data model

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -16,6 +16,8 @@ class Work < ActiveFedora::Base
   property :genre, predicate: ::RDF::Vocab::EDM.hasType
   property :normalized_date, predicate: ::RDF::Vocab::DC11.date
   property :repository, predicate: ::RDF::Vocab::MODS.locationCopySublocation
+  property :latitude, predicate: ::RDF::Vocab::EXIF.gpsLatitude
+  property :longitude, predicate: ::RDF::Vocab::EXIF.gpsLongitude
 
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -43,4 +43,16 @@ RSpec.describe Work do
     expect(work.local_identifier).to include 'local_identifier'
     expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/identifier/)
   end
+
+  it "has latitude" do
+    work.latitude = ['39']
+    expect(work.latitude).to include '39'
+    expect(work.resource.dump(:ttl)).to match(/w3.org\/2003\/12\/exif\/ns#gpsLatitude/)
+  end
+
+  it "has longitude" do
+    work.longitude = ['-94']
+    expect(work.longitude).to include '-94'
+    expect(work.resource.dump(:ttl)).to match(/w3.org\/2003\/12\/exif\/ns#gpsLongitude/)
+  end
 end


### PR DESCRIPTION
This adds the latitude and longitude attributes
to the model.

This does not include searching and faceting. Because
these are one word terms, they do not need specific entries
in the the locale files.

Connected to #150
Connected to #148