### PR TITLE
Add funding_note to the model

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -13,6 +13,7 @@ class Work < ActiveFedora::Base
   end
 
   property :local_identifier, predicate: ::RDF::Vocab::DC11.identifier
+  property :funding_note, predicate: ::RDF::URI.intern('http://bibfra.me/vocab/marc/fundingInformation/')
   property :genre, predicate: ::RDF::Vocab::EDM.hasType
   property :normalized_date, predicate: ::RDF::Vocab::DC11.date
   property :repository, predicate: ::RDF::Vocab::MODS.locationCopySublocation

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -4,3 +4,4 @@ simple_form:
       repository: 'Repository'
       normalized_date: 'Date'
       local_identifier: 'Local Identifier'
+      funding_note: 'Funding Note'

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -43,4 +43,10 @@ RSpec.describe Work do
     expect(work.local_identifier).to include 'local_identifier'
     expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/identifier/)
   end
+
+  it "has funding_note" do
+    work.funding_note = ['funding_note']
+    expect(work.funding_note).to include 'funding_note'
+    expect(work.resource.dump(:ttl)).to match(/bibfra.me\/vocab\/marc\/fundingInformation/)
+  end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Work do
     expect(work.funding_note).to include 'funding_note'
     expect(work.resource.dump(:ttl)).to match(/bibfra.me\/vocab\/marc\/fundingInformation/)
   end
-    
+
   it "has latitude" do
     work.latitude = ['39']
     expect(work.latitude).to include '39'


### PR DESCRIPTION
This adds the funding_note term to the model.

The predicate URI is not in RDF::Vocab so it is used
directly in this commit.

Connected to #171