### PR TITLE
Add custom terms to form

### DIFF
--- a/app/forms/hyrax/work_form.rb
+++ b/app/forms/hyrax/work_form.rb
@@ -5,6 +5,10 @@ module Hyrax
   # Generated form for Work
   class WorkForm < Hyrax::Forms::WorkForm
     self.model_class = ::Work
-    self.terms += [:resource_type]
+    self.terms += [:resource_type, :extent, :caption, :dimensions,
+                   :funding_note, :genre, :latitude,
+                   :longitude, :local_identifier, :medium,
+                   :named_subject, :normalized_date, :repository,
+                   :rights_country, :rights_holder]
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -45,6 +45,16 @@ en:
           rights_statement_tesim: Rights Statement
           subject_tesim: Subject
           title_tesim: Title
+  simple_form:
+    labels:
+      defaults:
+        funding_note: 'Funding Note'
+        local_identifier: 'Local Identifier'
+        named_subject: 'Name (Subject)'
+        normalized_date: 'Date'
+        repository: 'Repository'
+        rights_country: 'Rights (country of creation)'
+        rights_holder: 'Rights Holder'
   hyrax:
     account_name: My Institution Account Id
     directory:

--- a/spec/forms/hyrax/work_form_spec.rb
+++ b/spec/forms/hyrax/work_form_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::WorkForm do
+  let(:form) { described_class.new(Work.new, {}, {}) }
+
+  it 'has all the custom terms' do
+    expect(form.terms).to include(:extent, :caption, :dimensions,
+                                  :funding_note, :genre, :latitude,
+                                  :longitude, :local_identifier, :medium,
+                                  :named_subject, :normalized_date, :repository,
+                                  :rights_country, :rights_holder)
+  end
+end


### PR DESCRIPTION
This commit adds the custom terms to the `WorkForm` object.
By adding these terms to that object, they become editable
on the work's form in the editing interface. This also
adds additional locale config so that they show up on
the edit screen with the correct labels.