### PR TITLE
Add spec for publisher

### DIFF
--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe Work do
     end
   end
 
+  it "has publisher" do
+    work.publisher = ['publisher']
+    expect(work.publisher).to include 'publisher'
+    expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/publisher/)
+  end
+
   it "has extent" do
     work.extent = ['1 photograph']
     expect(work.extent).to include '1 photograph'


### PR DESCRIPTION
This commit adds a test for the `publisher` term.

This is present in `Hyrax::BasicMetadata` already. This
test will fail if the predicate changes upstream.

Connected to #106