### PR TITLE
Set 'repository' field when importing records from CSV.  Connected to #121

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -18,7 +18,8 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     genre: "Type.genre",
     rights_holder: "Rights.rightsHolderContact",
     medium: "Format.medium",
-    normalized_date: "Date.normalized"
+    normalized_date: "Date.normalized",
+    repository: "Name.repository"
   }.freeze
 
   DELIMITER = '|~|'
@@ -34,11 +35,24 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   # To avoid having to normalize data before import,
   # if the collection is LADNN, hard-code the extent. (Story #111)
   def extent
-    if metadata['Project Name'] == 'Los Angeles Daily News Negatives'
+    if ladnn?
       ['1 photograph']
     else
       map_field(:extent)
     end
+  end
+
+  # Hard-code repository for LADNN collection. Story #121
+  def repository
+    if ladnn?
+      ['University of California, Los Angeles. Library. Department of Special Collections']
+    else
+      map_field(:repository)
+    end
+  end
+
+  def ladnn?
+    metadata['Project Name'] == 'Los Angeles Daily News Negatives'
   end
 
   def map_field(name)

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -72,4 +72,28 @@ RSpec.describe CalifornicaMapper do
       end
     end
   end
+
+  describe '#repository' do
+    context 'when collection is LADNN' do
+      let(:metadata) do
+        { "Project Name" => "Los Angeles Daily News Negatives",
+          "Name.repository" => "This value is ignored" }
+      end
+
+      it 'hard codes the repository field' do
+        expect(mapper.repository).to eq ['University of California, Los Angeles. Library. Department of Special Collections']
+      end
+    end
+
+    context 'when it doesn\'t require special handling' do
+      let(:metadata) do
+        { "Project Name" => "Another collection",
+          "Name.repository" => "Repo 1|~|Repo 2" }
+      end
+
+      it 'reads the value from the metadata' do
+        expect(mapper.repository).to contain_exactly("Repo 1", "Repo 2")
+      end
+    end
+  end
 end

--- a/spec/tasks/ingest_spec.rb
+++ b/spec/tasks/ingest_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'californica:ingest:csv' do
       expect(created_work.rights_holder).to eq ['UCLA Charles E. Young Research Library Department of Special Collections, A1713 Young Research Library, Box 951575, Los Angeles, CA 90095-1575. E-mail: spec-coll@library.ucla.edu. Phone: (310)825-4988']
       expect(created_work.medium).to eq ['1 photograph']
       expect(created_work.normalized_date).to eq ['1947-09-17']
+      expect(created_work.repository).to eq ['University of California, Los Angeles. Library. Department of Special Collections']
     end
 
     it 'has created a public work' do


### PR DESCRIPTION
When the collection is "Los Angeles Daily News Negatives", ignore what's
in the CSV file, and hard-code the value of the repository field.  (This
decision was discussed in story #70.)

For all other collections, just import the values from the CSV file.