### PR TITLE
Move test workflow setup into a shared_context

### DIFF
--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -10,26 +10,14 @@ RSpec.feature 'Create a Work', js: false do
     let(:user_attributes) do
       { email: 'test@example.com' }
     end
+
     let(:user) do
       User.new(user_attributes) { |u| u.save(validate: false) }
     end
-    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
-    before do
-      # Create a single action that can be taken
-      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    include_context 'with workflow'
 
-      # Grant the user access to deposit into the admin set.
-      Hyrax::PermissionTemplateAccess.create!(
-        permission_template_id: permission_template.id,
-        agent_type: 'user',
-        agent_id: user.user_key,
-        access: 'deposit'
-      )
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/importers/actor_record_importer_spec.rb
+++ b/spec/importers/actor_record_importer_spec.rb
@@ -12,30 +12,7 @@ RSpec.describe ActorRecordImporter do
   let(:metadata_hash) { { 'title' => ['Comet in Moominland'] } }
 
   describe '#import' do
-    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-
-    let(:permission_template) do
-      Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
-    end
-
-    let(:workflow) do
-      Sipity::Workflow.create!(active:              true,
-                               name:                'test-workflow',
-                               permission_template: permission_template)
-    end
-
-    before do
-      # Create a single action that can be taken
-      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
-
-      # Grant the user access to deposit into the admin set.
-      Hyrax::PermissionTemplateAccess.create!(
-        permission_template_id: permission_template.id,
-        agent_type: 'user',
-        agent_id: User.find_or_create_system_user(described_class::DEFAULT_CREATOR_KEY),
-        access: 'deposit'
-      )
-    end
+    include_context 'with workflow'
 
     it 'creates a work for record' do
       expect { importer.import(record: record) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require 'ffaker'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/shared_contexts/workflow.rb
+++ b/spec/support/shared_contexts/workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with workflow' do
+  before :context do
+    admin_set_id        = AdminSet.find_or_create_default_admin_set_id
+    permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
+    workflow            = Sipity::Workflow.create!(active:              true,
+                                                   name:                'test-workflow',
+                                                   permission_template: permission_template)
+
+    # Create a single action that can be taken
+    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+  end
+
+  after(:context) do
+    ActiveFedora::Cleaner.clean!
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
Workflow setup had become duplicated across multiple tests. Changing setup to an
rspec `shared_context` removes duplication and makes workflow easy to reuse.

See: https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-context