### PR TITLE
Refine database cleanup strategy

### DIFF
--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Work', js: false do
+RSpec.feature 'Create a Work', :clean, js: false do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -10,26 +10,14 @@ RSpec.feature 'Create a Work', :clean, js: false do
     let(:user_attributes) do
       { email: 'test@example.com' }
     end
+
     let(:user) do
       User.new(user_attributes) { |u| u.save(validate: false) }
     end
-    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
-    before do
-      # Create a single action that can be taken
-      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    include_context 'with workflow'
 
-      # Grant the user access to deposit into the admin set.
-      Hyrax::PermissionTemplateAccess.create!(
-        permission_template_id: permission_template.id,
-        agent_type: 'user',
-        agent_id: user.user_key,
-        access: 'deposit'
-      )
-      login_as user
-    end
+    before { login_as user }
 
     scenario do
       visit '/dashboard'

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -21,12 +21,12 @@ RSpec.feature 'Edit an existing work', :clean do
     }
   end
 
+  include_context 'with workflow'
+
   context 'logged in as an admin user' do
     let(:admin) { FactoryBot.create :admin }
 
-    before do
-      login_as admin
-    end
+    before { login_as admin }
 
     scenario 'successfully edits the work' do
       visit edit_hyrax_work_path(work.id)

--- a/spec/importers/actor_record_importer_spec.rb
+++ b/spec/importers/actor_record_importer_spec.rb
@@ -12,30 +12,7 @@ RSpec.describe ActorRecordImporter, :clean do
   let(:metadata_hash) { { 'title' => ['Comet in Moominland'] } }
 
   describe '#import' do
-    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-
-    let(:permission_template) do
-      Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
-    end
-
-    let(:workflow) do
-      Sipity::Workflow.create!(active:              true,
-                               name:                'test-workflow',
-                               permission_template: permission_template)
-    end
-
-    before do
-      # Create a single action that can be taken
-      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
-
-      # Grant the user access to deposit into the admin set.
-      Hyrax::PermissionTemplateAccess.create!(
-        permission_template_id: permission_template.id,
-        agent_type: 'user',
-        agent_id: User.find_or_create_system_user(described_class::DEFAULT_CREATOR_KEY),
-        access: 'deposit'
-      )
-    end
+    include_context 'with workflow'
 
     it 'creates a work for record' do
       expect { importer.import(record: record) }

--- a/spec/importers/actor_record_importer_spec.rb
+++ b/spec/importers/actor_record_importer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe ActorRecordImporter do
+RSpec.describe ActorRecordImporter, :clean do
   subject(:importer) do
     described_class.new(error_stream: error_stream, info_stream: info_stream)
   end

--- a/spec/importers/californica_csv_parser_spec.rb
+++ b/spec/importers/californica_csv_parser_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CalifornicaCsvParser do
   let(:file)       { File.open(csv_path) }
   let(:csv_path)   { 'spec/fixtures/example.csv' }
 
-  describe 'use in an importer' do
+  describe 'use in an importer', :clean do
     let(:importer) { Darlingtonia::Importer.new(parser: parser) }
 
     it 'imports records' do

--- a/spec/importers/californica_importer_spec.rb
+++ b/spec/importers/californica_importer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe CalifornicaImporter do
+RSpec.describe CalifornicaImporter, :clean do
   subject(:importer) { described_class.new(file) }
   let(:file)       { File.open(csv_path) }
   let(:csv_path)   { 'spec/fixtures/example.csv' }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,8 +39,14 @@ RSpec.configure do |config|
     DatabaseCleaner.start
   end
 
-  config.before(clean: true) do
-    DatabaseCleaner.clean
+  config.before(clean: true) do |example|
+    if example.metadata[:type] == :feature && Capybara.current_driver != :rack_test
+      DatabaseCleaner.strategy = :truncation
+    else
+      DatabaseCleaner.strategy = :transaction
+      DatabaseCleaner.start
+    end
+
     ActiveFedora::Cleaner.clean!
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require 'ffaker'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/shared_contexts/workflow.rb
+++ b/spec/support/shared_contexts/workflow.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'with workflow' do
-  before :context do
+  before do
     admin_set_id        = AdminSet.find_or_create_default_admin_set_id
     permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
     workflow            = Sipity::Workflow.create!(active:              true,
@@ -12,7 +12,7 @@ RSpec.shared_context 'with workflow' do
     Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
   end
 
-  after(:context) do
+  after do
     ActiveFedora::Cleaner.clean!
     DatabaseCleaner.clean
   end

--- a/spec/support/shared_contexts/workflow.rb
+++ b/spec/support/shared_contexts/workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with workflow' do
+  before :context do
+    admin_set_id        = AdminSet.find_or_create_default_admin_set_id
+    permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
+    workflow            = Sipity::Workflow.create!(active:              true,
+                                                   name:                'test-workflow',
+                                                   permission_template: permission_template)
+
+    # Create a single action that can be taken
+    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+  end
+
+  after(:context) do
+    ActiveFedora::Cleaner.clean!
+    DatabaseCleaner.clean
+  end
+end

--- a/spec/tasks/ingest_spec.rb
+++ b/spec/tasks/ingest_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'californica:ingest:csv' do
+RSpec.describe 'californica:ingest:csv', :clean do
   subject(:task)  { rake[task_name] }
   let(:csv_path)  { 'spec/fixtures/example.csv' }
   let(:rake)      { Rake::Application.new }


### PR DESCRIPTION
This addresses latent order dependency in the test suite. Cleanup is more systematically handled by mixing the `:truncation` and `:transaction` cleanup strategies.