### PR TITLE
Use the `ActorRecordImporter` when importing via the rake task

### DIFF
--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -13,7 +13,7 @@ class CalifornicaImporter
   def import
     start_time = Time.zone.now
     @info_stream << "Beginning ingest process at #{start_time}"
-    record_importer = Darlingtonia::RecordImporter.new(error_stream: @error_stream, info_stream: @info_stream)
+    record_importer = ActorRecordImporter.new(error_stream: @error_stream, info_stream: @info_stream)
     Darlingtonia::Importer.new(parser: parser, record_importer: record_importer).import if parser.validate
     end_time = Time.zone.now
     elapsed_time = end_time - start_time

--- a/spec/importers/californica_importer_spec.rb
+++ b/spec/importers/californica_importer_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe CalifornicaImporter, :clean do
       expect { importer.import }.to change { Work.count }.by 1
     end
 
+    it 'sets #date_uploaded' do
+      importer.import
+      expect(Work.last.date_uploaded).not_to be_nil
+    end
+
     it "has an ingest log" do
       expect(importer.ingest_log).to be_kind_of(Logger)
     end


### PR DESCRIPTION
This replaces the default `Darlingtonia::RecordImporter`, with the new `ActorRecordImporter` to route imports through the Actor Stack. We leave the dependency hard coded for now.