### PR TITLE
Add a service to reindex to another server

### DIFF
--- a/app/services/reindex_service.rb
+++ b/app/services/reindex_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ReindexService
+  attr_reader :solr
+
+  # @param solr [String] the url for your alternate solr server
+  def initialize(solr:)
+    @original_solr = ActiveFedora::SolrService.instance.options[:url]
+    @solr = solr
+  end
+
+  # Switches out the ActiveFedora::SolrService connection to a
+  # a solr server that you specify and then reindexes your
+  # repository content for that server. It then restores the original
+  # connection
+  #
+  # @return [Boolean] the reindex success
+  def reindex
+    ActiveFedora::SolrService.instance.conn = RSolr.connect url: @solr
+    result = ActiveFedora::Base.reindex_everything
+    ActiveFedora::SolrService.instance.conn = RSolr.connect url: @original_solr
+    result
+  end
+end

--- a/spec/services/reindex_service_spec.rb
+++ b/spec/services/reindex_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReindexService do
+  let(:reindex_service) { described_class.new(solr: ActiveFedora::SolrService.instance.options[:url]) }
+
+  it 'is a class that can be initialized' do
+    expect(reindex_service).not_to eq(nil)
+  end
+
+  it 'has a reindex method that succeeds' do
+    expect(reindex_service.reindex).to eq(true)
+  end
+end


### PR DESCRIPTION
This commit includes a service that reindexes
the contents of the repository to another solr
server.

It is intended to be used with a Rake task.

Connected to #214