### PR TITLE
Rake task to bulk reindex the solr index for Ursus.  Part of story #214.

### DIFF
--- a/lib/tasks/ursus.rake
+++ b/lib/tasks/ursus.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :californica do
+  desc 'Update Ursus solr index with the latest data from Californica'
+  task reindex_ursus: :environment do
+    unless ENV['URSUS_SOLR_URL']
+      puts "Aborting reindex. Please set environment variable: URSUS_SOLR_URL"
+      next
+    end
+
+    start_time = Time.zone.now
+    puts "Begin reindex of Ursus solr: #{start_time}"
+
+    ReindexService.new(solr: ENV['URSUS_SOLR_URL']).reindex
+
+    end_time = Time.zone.now
+    elapsed_time = (end_time - start_time).to_i
+    puts "Ursus solr reindex complete.  Elapsed time in seconds: #{elapsed_time}"
+  end
+end


### PR DESCRIPTION
You need to set an environment variable for the Ursus solr URL.  You can
run rake task like this:

URSUS_SOLR_URL="http://127.0.0.1:8987/solr/development-ursus" rake
californica:reindex_ursus

This is part of a research spike to determine how we'll set up solr for
Ursus, and how to keep Ursus up-to-date with the latest data from
Californica.