### PR TITLE
Clean `PermissionTemplate` instances when clean task destroys AdminSets

### DIFF
--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -18,10 +18,13 @@ namespace :californica do
     desc "Cleanout fedora"
     task clean: :environment do
       require 'active_fedora/cleaner'
+
       # Re-try the cleanout process a few times in case it times out
       with_retries(max_tries: 10, base_sleep_seconds: 500, max_sleep_seconds: 1000) do
         ActiveFedora::Cleaner.clean!
       end
+
+      Hyrax::PermissionTemplate.destroy_all
     end
 
     # While we are in development mode, this task is scheduled to run nightly.


### PR DESCRIPTION
When destroying an `AdminSet`, the attached `PermissionTemplate` in the
relational database need to be cleaned up. If this is neglected, recreating the
default `AdminSet` (or any other admin set with a previously existing id).

The `californica:ingest:clean` task is changed to destroy existing permission
templates after running `ActiveFedora::Cleaner.clean!`.

This should restore the functionality of nightly ingest.

Closes https://github.com/UCLALibrary/amalgamated-samvera/issues/101