### PR TITLE
Add sidekiq-failures gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'retries'
 gem 'riiif', '~> 1.1'
 gem 'rsolr', '>= 1.0'
 gem 'sidekiq', '~> 5.1.3'
+gem 'sidekiq-failures'
 gem 'whenever', require: false
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -726,6 +726,8 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-failures (1.0.0)
+      sidekiq (>= 4.0.0)
     signet (0.10.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -855,6 +857,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq (~> 5.1.3)
+  sidekiq-failures
   solr_wrapper (>= 0.3)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
We'd like to see failures on the sidekiq dashboard. This adds a tab with a list of failures (by default limited to 1000, but that's configurable), but strangely doesn't link the failures count (like retries et al. are linked). Still, good enough for a first pass.

Connected to #241 