### PR TITLE
Fixed a problem where error messages from validators weren't getting printed to the error log file.

### DIFF
--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class CalifornicaCsvParser < Darlingtonia::CsvParser
-  DEFAULT_VALIDATORS = [
-    Darlingtonia::CsvFormatValidator.new,
-    Darlingtonia::TitleValidator.new
-  ].freeze
-
   ##
   # @!attribute [rw] error_stream
   #   @return [#<<]
@@ -25,6 +20,11 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
                  **opts)
     self.error_stream = error_stream
     self.info_stream  = info_stream
+
+    self.validators = [
+      Darlingtonia::CsvFormatValidator.new(error_stream: error_stream),
+      Darlingtonia::TitleValidator.new(error_stream: error_stream)
+    ]
 
     super
   end

--- a/spec/importers/californica_csv_parser_spec.rb
+++ b/spec/importers/californica_csv_parser_spec.rb
@@ -48,4 +48,14 @@ RSpec.describe CalifornicaCsvParser do
       end
     end
   end
+
+  describe 'validators' do
+    subject(:parser) { described_class.new(file: file, error_stream: error_stream) }
+
+    let(:error_stream) { CalifornicaLogStream.new }
+
+    it 'use the same error stream as the parser' do
+      expect(parser.validators.map(&:error_stream)).to eq [error_stream, error_stream]
+    end
+  end
 end


### PR DESCRIPTION
The validator classes should use the parent parser's error stream.