### PR TITLE
Remove nightly reingest

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,11 +31,11 @@ every :day, at: '3:00am' do
 end
 
 # Delete everything and give Fedora time to process the request
-every :day, at: '1:00am' do
-  rake "californica:ingest:clean"
-end
+# every :day, at: '1:00am' do
+#   rake "californica:ingest:clean"
+# end
 
 # Reingest news negatives collection daily
-every :day, at: '2:00am' do
-  rake "californica:ingest:reingest"
-end
+# every :day, at: '2:00am' do
+#   rake "californica:ingest:reingest"
+# end


### PR DESCRIPTION
The nightly re-ingest isn't working and it
doesn't seem worthwhile to spend more
time on it right now. Instead, let's do
a re-ingest manually when it's warranted.

Connected to #238 