### PR TITLE
Replace MaRC codes with double dashes

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -61,6 +61,11 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     end
   end
 
+  # Normalize subject to remove MaRC codes (e.g., $z separators)
+  def subject
+    map_field(:subject).map { |a| a.gsub(/ \$[a-z] /, '--') }
+  end
+
   # Hard-code language for LADNN collection. Story #48
   def language
     if ladnn?

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -130,4 +130,17 @@ RSpec.describe CalifornicaMapper do
       end
     end
   end
+
+  describe '#subject' do
+    context 'when it contains MaRC separators' do
+      let(:metadata) do
+        { "Project Name" => "Los Angeles Daily News Negatives",
+          "Name.repository" => "Repo 1|~|Repo 2",
+          "Subject" => "Wrestlers $z California $z Los Angeles|~|Los Angeles County (Calif.). $b Board of Supervisors" }
+      end
+      it 'replaces them with double dashes' do
+        expect(mapper.subject).to contain_exactly("Wrestlers--California--Los Angeles", "Los Angeles County (Calif.).--Board of Supervisors")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some subjects have MaRC codes (e.g., $z) as
separators, instead of the usual double dash.
Normalize these so they match the standard
practice.

Connected to https://github.com/UCLALibrary/amalgamated-samvera/issues/51