### PR TITLE
Fix location facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -59,7 +59,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('medium', :facetable), limit: 5
     config.add_facet_field solr_name('dimensions', :facetable), limit: 5
     config.add_facet_field solr_name('extent', :facetable), limit: 5
-    config.add_facet_field solr_name('location', :stored_searchable), label: 'Location', limit: 5
+    config.add_facet_field solr_name('location', :facetable), label: 'Location', limit: 5
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -33,7 +33,7 @@ class Work < ActiveFedora::Base
   end
 
   property :location, predicate: ::RDF::Vocab::DC.coverage do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   property :local_identifier, predicate: ::RDF::Vocab::DC11.identifier do |index|


### PR DESCRIPTION
Previously, location was not being indexed or
displayed as a facet, so when it appeared in the
facet menu the values didn't make a lot of sense.
This change makes the location facet more useful.