### PR TITLE
Skip records with ENV['SKIP']

### DIFF
--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -29,6 +29,13 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
     super
   end
 
+  # Skip this number of records before starting the ingest process. Default is 0.
+  # Useful for re-starting a failed ingest without having to blow everything away.
+  def skip
+    return 0 unless ENV['SKIP']
+    ENV['SKIP'].to_s.to_i
+  end
+
   def records
     return enum_for(:records) unless block_given?
     file.rewind
@@ -37,6 +44,7 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
 
     # use the CalifornicaMapper
     CSV.parse(file.read, headers: true).each_with_index do |row, index|
+      next unless index >= skip
       next if row.to_h.values.all?(&:nil?)
       yield Darlingtonia::InputRecord.from(metadata: row, mapper: CalifornicaMapper.new)
       actual_records_processed += 1

--- a/spec/importers/californica_csv_parser_spec.rb
+++ b/spec/importers/californica_csv_parser_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe CalifornicaCsvParser do
   let(:file)       { File.open(csv_path) }
   let(:csv_path)   { 'spec/fixtures/example.csv' }
 
+  after do
+    ENV['SKIP'] = '0'
+  end
+
   describe 'use in an importer', :clean do
     include_context 'with workflow'
 
@@ -16,6 +20,11 @@ RSpec.describe CalifornicaCsvParser do
 
     it 'imports records' do
       expect { importer.import }.to change { Work.count }.by 1
+    end
+
+    it 'skips records if ENV[\'SKIP\'] is set' do
+      ENV['SKIP'] = '1'
+      expect { importer.import }.to change { Work.count }.by 0
     end
   end
 


### PR DESCRIPTION
When a long running ingest fails partway through,
we want to be able to restart it where it left off.
We can now do this by setting a SKIP environment
variable like this:

SKIP=5 rake californica:ingest:sample

Connected to https://github.com/UCLALibrary/amalgamated-samvera/issues/137