### PR TITLE
Import copyright status from CSV file. Story #97

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Exclude:
     - 'spec/tasks/ingest_spec.rb'
+    - 'app/importers/rights_statement_validator.rb'
 
 Metrics/MethodLength:
   Enabled: true

--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -23,7 +23,8 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
 
     self.validators = [
       Darlingtonia::CsvFormatValidator.new(error_stream: error_stream),
-      Darlingtonia::TitleValidator.new(error_stream: error_stream)
+      Darlingtonia::TitleValidator.new(error_stream: error_stream),
+      RightsStatementValidator.new(error_stream: error_stream)
     ]
 
     super

--- a/app/importers/rights_statement_validator.rb
+++ b/app/importers/rights_statement_validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class RightsStatementValidator < Darlingtonia::Validator
+  def run_validation(parser:, **)
+    parser.records.each_with_object([]) do |record, errors|
+      parsed_values = record.respond_to?(:rights_statement) ? Array(record.rights_statement) : []
+
+      invalid_values = parsed_values - valid_values
+
+      unless invalid_values.blank?
+        errors << Error.new(record, :invalid_rights_statement, "The 'Rights.copyrightStatus' field contains an invalid value.  If this value is correct, you'll need to update 'config/authorities/rights_statements.yml' to allow this new value.  The invalid values are: #{invalid_values.join(', ')}")
+      end
+    end
+  end
+
+  # Hyrax expects the rights_statement to be a valid
+  # value as defined in:
+  # config/authorities/rights_statements.yml.
+  def valid_values
+    @valid_values ||= Qa::Authorities::Local.subauthority_for('rights_statements').all.map { |term| term['id'] }
+  end
+end

--- a/spec/fixtures/example-invalid-rights_statement.csv
+++ b/spec/fixtures/example-invalid-rights_statement.csv
@@ -1,0 +1,4 @@
+"Item Ark","Title","Rights.copyrightStatus"
+"111","Title 1","copyrighted"
+"222","Title 2",
+"333","Title 3","invalid data"

--- a/spec/importers/californica_csv_parser_spec.rb
+++ b/spec/importers/californica_csv_parser_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe CalifornicaCsvParser do
     let(:error_stream) { CalifornicaLogStream.new }
 
     it 'use the same error stream as the parser' do
-      expect(parser.validators.map(&:error_stream)).to eq [error_stream, error_stream]
+      expect(parser.validators.map(&:error_stream)).to eq [error_stream, error_stream, error_stream]
     end
   end
 end

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -144,4 +144,37 @@ RSpec.describe CalifornicaMapper do
       end
     end
   end
+
+  describe '#rights_statement' do
+    context 'when the field is blank' do
+      # No value for "Rights.copyrightStatus"
+      let(:metadata) { { 'Title' => 'A title' } }
+
+      it 'returns nil' do
+        expect(mapper.rights_statement).to eq nil
+      end
+    end
+
+    context 'with a valid value' do
+      let(:metadata) do
+        { 'Title' => 'A title',
+          'Rights.copyrightStatus' => 'copyrighted' }
+      end
+
+      it 'finds the correct ID for the given value' do
+        expect(mapper.rights_statement).to eq 'http://rightsstatements.org/vocab/InC/1.0/'
+      end
+    end
+
+    context 'with an invalid value' do
+      let(:metadata) do
+        { 'Title' => 'A title',
+          'Rights.copyrightStatus' => 'something invalid' }
+      end
+
+      it 'returns the same value' do
+        expect(mapper.rights_statement).to eq 'something invalid'
+      end
+    end
+  end
 end

--- a/spec/importers/rights_statement_validator_spec.rb
+++ b/spec/importers/rights_statement_validator_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe RightsStatementValidator do
+  subject(:validator) { described_class.new(error_stream: []) }
+
+  let(:csv_file) { File.join(fixture_path, 'example-invalid-rights_statement.csv') }
+  let(:open_file) { File.open(csv_file) }
+  after { open_file.close }
+
+  let(:parser) { CalifornicaCsvParser.new(file: open_file, error_stream: [], info_stream: []) }
+
+  it 'returns errors for invalid rights statements' do
+    return_value = validator.validate(parser: parser)
+    expect(return_value.map(&:class)).to eq [Darlingtonia::Validator::Error]
+    expect(return_value.first.description).to match(/The invalid values are: invalid data/)
+  end
+end


### PR DESCRIPTION
* The mapper will use the label from the CSV file to find the ID that needs to be stored for the rights_statement.

* A validator checks to make sure the values in the CSV file are valid.  The CSV file will be rejected if there are invalid values.

* I added the lonely operator to the 'subject' method in the mapper because it was causing errors when I tried to import CSV files that don't have a subject column.

Connected to #97