### PR TITLE
Alleviate travis timeout errors by caching download zips

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   bundler: true
   directories:
     - tmp/solr_downloads
+    - tmp/fedora_downloads
 dist: trusty
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 sudo: false
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - tmp/solr_downloads
 dist: trusty
 jdk:
 - oraclejdk8

--- a/config/fcrepo_wrapper_test.yml
+++ b/config/fcrepo_wrapper_test.yml
@@ -2,3 +2,4 @@
 port: 8986
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-test-data
+download_dir: tmp/fedora_downloads

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,7 +1,7 @@
-#config/solr_wrapper_test.yml
 # version: 6.1.0
 port: 8985
 instance_dir: tmp/solr-test
+download_dir: tmp/solr_downloads
 collection:
     persist: false
     dir: solr/config

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -5,7 +5,6 @@ unless Rails.env.production?
   require 'solr_wrapper/rake_task'
 
   task :spec_with_server do
-    require 'resolv-replace'
     with_server 'test' do
       Rake::Task['spec'].invoke
     end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -5,6 +5,7 @@ unless Rails.env.production?
   require 'solr_wrapper/rake_task'
 
   task :spec_with_server do
+    require 'resolv-replace'
     with_server 'test' do
       Rake::Task['spec'].invoke
     end


### PR DESCRIPTION
The recent travis timeouts that I've seen have had to do with downloading the solr files.  I added a cache to the travis config to keep previous downloads to avoid constantly having to re-download the same files.

This will alleviate some of the network timeout problems, but it won't fully solve them.  Even after caching the files, I still see some timeout errors from solr_wrapper's `fetch_latest_version` method.  If we decide we want to eliminate that error, we'll need to explicitly set the solr version in `config/solr_wrapper_test.yml` (and probably need to similarly set the fedora version in `config/fcrepo_wrapper_test.yml`).  If we decide to do that in the future, we can submit that as a separate PR.