### PR TITLE
Index latitude and longitude into a single field for display. Story ursus#22

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -10,10 +10,14 @@ class WorkIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
-  # Uncomment this block if you want to add custom indexing behavior:
-  # def generate_solr_document
-  #  super.tap do |solr_doc|
-  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
-  #  end
-  # end
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc['geographic_coordinates_ssim'] = coordinates
+    end
+  end
+
+  def coordinates
+    return unless object.latitude.first && object.longitude.first
+    [object.latitude.first, object.longitude.first].join(', ')
+  end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe WorkIndexer do
+  let(:solr_document) { indexer.generate_solr_document }
+  let(:work) { Work.new(attributes) }
+  let(:indexer) { described_class.new(work) }
+
+  describe 'latitude and longitude' do
+    context 'a work with latitude and longitude' do
+      let(:attributes) do
+        { latitude: ['45.0'],
+          longitude: ['-93.0'] }
+      end
+
+      it 'indexes the coordinates in a single field' do
+        expect(solr_document['geographic_coordinates_ssim']).to eq '45.0, -93.0'
+      end
+    end
+
+    context 'a work that is missing latitude' do
+      let(:attributes) { { longitude: ['-93.0'] } }
+
+      it 'doesn\'t index the coordinates' do
+        expect(solr_document['geographic_coordinates_ssim']).to eq nil
+      end
+    end
+
+    context 'a work that is missing longitude' do
+      let(:attributes) { { latitude: ['45.0'] } }
+
+      it 'doesn\'t index the coordinates' do
+        expect(solr_document['geographic_coordinates_ssim']).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to display latitude and longitude as a single field, so I added
a solr index with the data in the format that we want to display in
Ursus.

Connected to https://github.com/UCLALibrary/ursus/issues/22