### PR TITLE
Revise search result field order in catalog_controller.rb

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,25 +73,9 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
-    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field solr_name('keyword', :stored_searchable), itemprop: 'keywords', link_to_search: solr_name('keyword', :facetable)
-    config.add_index_field solr_name('subject', :stored_searchable), itemprop: 'about', link_to_search: solr_name('subject', :facetable)
-    config.add_index_field solr_name('creator', :stored_searchable), itemprop: 'creator', link_to_search: solr_name('creator', :facetable)
-    config.add_index_field solr_name('contributor', :stored_searchable), itemprop: 'contributor', link_to_search: solr_name('contributor', :facetable)
-    config.add_index_field solr_name('proxy_depositor', :symbol), label: 'Depositor', helper_method: :link_to_profile
-    config.add_index_field solr_name('publisher', :stored_searchable), itemprop: 'publisher', link_to_search: solr_name('publisher', :facetable)
-    config.add_index_field solr_name('based_near_label', :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name('based_near_label', :facetable)
-    config.add_index_field solr_name('language', :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name('language', :facetable)
-    config.add_index_field solr_name('date_uploaded', :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
-    config.add_index_field solr_name('date_modified', :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
-    config.add_index_field solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field solr_name('rights_statement', :stored_searchable), helper_method: :rights_statement_links
-    config.add_index_field solr_name('license', :stored_searchable), helper_method: :license_links
+    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'Description', helper_method: :iconify_auto_link
+    config.add_index_field solr_name('normalized_date', :stored_searchable), label: 'Date', link_to_search: solr_name('normalized_date', :facetable)
     config.add_index_field solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: solr_name('resource_type', :facetable)
-    config.add_index_field solr_name('file_format', :stored_searchable), link_to_search: solr_name('file_format', :facetable)
-    config.add_index_field solr_name('identifier', :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
-    config.add_index_field solr_name('embargo_release_date', :stored_sortable, type: :date), label: 'Embargo release date', helper_method: :human_readable_date
-    config.add_index_field solr_name('lease_expiration_date', :stored_sortable, type: :date), label: 'Lease expiration date', helper_method: :human_readable_date
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/features/import_and_show_work_spec.rb
+++ b/spec/features/import_and_show_work_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
   end
 
   context "after import" do
-    it "displays expected fields" do
+    it "displays expected fields on show work page" do
       importer.import
       work = Work.last
       visit("/concern/works/#{work.id}")
@@ -42,6 +42,15 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
       expect(page).to have_content "Fake Caption" # caption
       expect(page).to have_content "No linguistic content" # language
       expect(page).to have_content "34.05707, -118.239577" # geographic_coordinates, a.k.a. latitude and longitude
+    end
+    it "displays expected fields on search results page" do
+      importer.import
+      work = Work.last
+      visit("catalog?search_field=all_fields&q=")
+      expect(page).to have_content work.title.first
+      expect(page).to have_content work.description.first
+      expect(page).to have_content work.normalized_date.first
+      expect(page).to have_content work.resource_type.first
     end
   end
 end


### PR DESCRIPTION
Connected to #264

- revise search result field order in catalog_controller
- revise import and show work feature spec to verify the expected fields
appear in a search results page