### PR TITLE
Do not use rightsstatement.org values for UCLA

### DIFF
--- a/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  module Renderers
+    # This is used by PresentsAttributes to show licenses
+    #   e.g.: presenter.attribute_to_html(:rights_statement, render_as: :rights_statement)
+    class RightsStatementAttributeRenderer < AttributeRenderer
+      private
+
+        ##
+        # Override Hyrax's default behavior to link copyright to the URI.
+        # In UCLA's case, we are using a non-resolving placeholder URI. Note
+        # that we should NOT use rightsstatement.org URIs until there is
+        # an administrative policy in place approving their use.
+        def attribute_value_to_html(value)
+          Hyrax.config.rights_statement_service_class.new.label(value) { value }
+        end
+    end
+  end
+end

--- a/config/authorities/rights_statements.yml
+++ b/config/authorities/rights_statements.yml
@@ -1,4 +1,6 @@
+# Note that UCLA is not authorized to use rightsstatements.org values.
+# This file overrides the default URI values.
 terms:
-- id: http://rightsstatements.org/vocab/InC/1.0/
+- id: http://vocabs.library.ucla.edu/rights/copyrighted
   term: "copyrighted"
   active: true

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Edit an existing work', :clean do
 
       # When the form first loads, it should contain all the old values
       expect(find_field('Title').value).to eq 'Old Title'
-      expect(page).to have_select('Copyright Status', selected: 'copyrighted')
+      expect(page.all(:css, 'div.select.work_rights_statement/select').first.text).to eq 'copyrighted'
       expect(first(:css, '#work_description').value).to eq 'Old Desc'
       expect(find_field('Publisher').value).to eq 'Old Pub'
       expect(find_field('Date Created').value).to eq 'Old Creation Date'

--- a/spec/features/import_and_show_work_spec.rb
+++ b/spec/features/import_and_show_work_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
       expect(page).to have_content "Historic buildings--California--Los Angeles" # $subject: $z has been replaced with --
       expect(page).to have_content "still image" # resource_type
       expect(page).to have_content "copyrighted" # rights_statement
+      expect(page).not_to have_css('li.attribute-rights_statement/a') # Rights statement should not link anywhere
       expect(page).to have_content "news photographs" # genre
       expect(page).to have_content "Plaza Church (Los Angeles, Calif.)" # named_subject
       expect(page).to have_content "University of California, Los Angeles. Library. Department of Special Collections" # repository

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -145,35 +145,37 @@ RSpec.describe CalifornicaMapper do
     end
   end
 
-  describe '#rights_statement' do
-    context 'when the field is blank' do
-      # No value for "Rights.copyrightStatus"
-      let(:metadata) { { 'Title' => 'A title' } }
+  context "UCLA has not agreed to use rightsstatement.org" do
+    describe '#rights_statement' do
+      context 'when the field is blank' do
+        # No value for "Rights.copyrightStatus"
+        let(:metadata) { { 'Title' => 'A title' } }
 
-      it 'returns nil' do
-        expect(mapper.rights_statement).to eq nil
-      end
-    end
-
-    context 'with a valid value' do
-      let(:metadata) do
-        { 'Title' => 'A title',
-          'Rights.copyrightStatus' => 'copyrighted' }
+        it 'returns nil' do
+          expect(mapper.rights_statement).to eq nil
+        end
       end
 
-      it 'finds the correct ID for the given value' do
-        expect(mapper.rights_statement).to eq 'http://rightsstatements.org/vocab/InC/1.0/'
-      end
-    end
+      context 'with a valid value' do
+        let(:metadata) do
+          { 'Title' => 'A title',
+            'Rights.copyrightStatus' => 'copyrighted' }
+        end
 
-    context 'with an invalid value' do
-      let(:metadata) do
-        { 'Title' => 'A title',
-          'Rights.copyrightStatus' => 'something invalid' }
+        it 'finds the correct ID for the given value' do
+          expect(mapper.rights_statement).to eq "http://vocabs.library.ucla.edu/rights/copyrighted"
+        end
       end
 
-      it 'returns the same value' do
-        expect(mapper.rights_statement).to eq 'something invalid'
+      context 'with an invalid value' do
+        let(:metadata) do
+          { 'Title' => 'A title',
+            'Rights.copyrightStatus' => 'something invalid' }
+        end
+
+        it 'returns the same value' do
+          expect(mapper.rights_statement).to eq 'something invalid'
+        end
       end
     end
   end


### PR DESCRIPTION
UCLA has not yet adopted rightsstatements.org so their values
are not allowed in UCLA data at this time. Instead:

* Use a placeholder URI for a UCLA specific copyright value
* Do not link copyright value to anything in the UI
* Update tests to reflect these expectations

Connected to https://github.com/UCLALibrary/californica/issues/284