### PR TITLE
Add a task to clean and re-ingest in one command

### DIFF
--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -13,6 +13,17 @@ namespace :californica do
       CalifornicaImporter.new(csv_file).import
     end
 
+    # This task is best run in production like this:
+    # cd /opt/californica/current
+    # RAILS_ENV=production nohup bundle exec rake californica:ingest:reingest &
+    # Note that this is a very long running task and if you do not run it
+    # with nohup or a similar strategy it might fail when your ssh connection ends.
+    desc 'Reingest LADNN'
+    task reingest: [:environment] do
+      Rake::Task["californica:ingest:clean"].invoke
+      Rake::Task["californica:ingest:ingest_ladnn"].invoke
+    end
+
     desc 'Ingest sample data'
     task sample: [:environment] do
       require 'active_fedora/cleaner'


### PR DESCRIPTION
This will let us set this to run when we leave for the day
and hopefully, now that the timeout issue is fixed,
come back the next morning to fresh clean data.

Connected to https://github.com/UCLALibrary/amalgamated-samvera/issues/166