### PR TITLE
Front page goes to default search. Story #297

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  root 'catalog#index'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'
 
@@ -17,7 +18,6 @@ Rails.application.routes.draw do
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'
-  root 'hyrax/homepage#index'
   curation_concerns_basic_routes
   concern :exportable, Blacklight::Routes::Exportable.new
 


### PR DESCRIPTION
* Changes the root route to just display search results instead of
default hyrax home page.

* Connected to #297