### PR TITLE
Add coverall badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 [![Build Status](https://travis-ci.org/UCLALibrary/californica.svg?branch=master)](https://travis-ci.org/UCLALibrary/californica) [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
 
+[![Test Coverage](https://coveralls.io/repos/github/UCLALibrary/californica/badge.svg?branch=master)](https://coveralls.io/github/UCLALibrary/californica?branch=master)
+
 ---
 
 ## Development


### PR DESCRIPTION
Add coverall badge so we can so how much of our code our tests are covering at a glance.

Connected to https://github.com/UCLALibrary/amalgamated-samvera/issues/180

[![Coverage Status](https://coveralls.io/repos/github/UCLALibrary/californica/badge.svg?branch=master)](https://coveralls.io/github/UCLALibrary/californica?branch=master)
