### PR TITLE
Configure Hyrax for external IIIF server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,3 +28,6 @@ REDIS_CABLE_DB=1
 SIDEKIQ_WORKERS=7
 SOLR_URL=http://127.0.0.1:8983/solr/californica
 CSV_FILE=/opt/data/sample_data_set_la_daily_news/dlcs-ladnn-2018-09-06.csv
+
+# If there is a non-RIIIF IIIF server, uncomment; else, leave commented
+# IIIF_SERVER_URL=http://127.0.0.1:8182/iiif/2/

--- a/.env.sample
+++ b/.env.sample
@@ -29,5 +29,5 @@ SIDEKIQ_WORKERS=7
 SOLR_URL=http://127.0.0.1:8983/solr/californica
 CSV_FILE=/opt/data/sample_data_set_la_daily_news/dlcs-ladnn-2018-09-06.csv
 
-# If there is a non-RIIIF IIIF server, uncomment; else, leave commented
+# If there is an external IIIF server, uncomment; else, leave commented
 # IIIF_SERVER_URL=http://127.0.0.1:8182/iiif/2/

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -141,22 +141,24 @@ Hyrax.config do |config|
   # Default is false
   config.iiif_image_server = true
 
-  # Returns a URL that resolves to an image provided by a IIIF image server
+  # If we have an external IIIF server, use it for image requests; else, use riiif
   config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
+    if ENV['IIIF_SERVER_URL'].present?
+      ENV['IIIF_SERVER_URL'] + file_id.gsub('/', '%2F') + "/" + size + "/full/0/default.jpg"
+    else
+      Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
+    end
   end
-  # config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-  #   "#{base_url}/downloads/#{file_id.split('/').first}"
-  # end
 
-  # Returns a URL that resolves to an info.json file provided by a IIIF image server
+  # If we have an external IIIF server, use it for info.json; else, use riiif
   config.iiif_info_url_builder = lambda do |file_id, base_url|
-    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
-    uri.sub(%r{/info\.json\Z}, '')
+    if ENV['IIIF_SERVER_URL'].present?
+      ENV['IIIF_SERVER_URL'] + file_id.gsub('/', '%2F')
+    else
+      uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
+      uri.sub(%r{/info\.json\Z}, '')
+    end
   end
-  # config.iiif_info_url_builder = lambda do |_, _|
-  #   ""
-  # end
 
   # Returns a URL that indicates your IIIF image server compliance level
   # config.iiif_image_compliance_level_uri = 'http://iiif.io/api/image/2/level2.json'


### PR DESCRIPTION
Gives the option to use an external IIIF server if the IIIF_SERVER_URL env variable has been set. If it's not been set, Hyrax falls back to using the local riiif server.

Connected to [uclalibrary/amalgamated_samvera#164](https://github.com/UCLALibrary/amalgamated-samvera/issues/164)