### PR TITLE
 Index the years from the normalized_date field. Story UCLALibrary/ursus#69

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,3 +59,11 @@ Layout/MultilineBlockLayout:
 Layout/BlockEndNewline:
   Exclude:
     - 'spec/features/search_catalog_spec.rb'
+
+Naming/PredicateName:
+  Exclude:
+    - 'app/indexers/year_parser.rb'
+
+Style/IfUnlessModifier:
+  Exclude:
+    - 'app/indexers/year_parser.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,11 +59,3 @@ Layout/MultilineBlockLayout:
 Layout/BlockEndNewline:
   Exclude:
     - 'spec/features/search_catalog_spec.rb'
-
-Naming/PredicateName:
-  Exclude:
-    - 'app/indexers/year_parser.rb'
-
-Style/IfUnlessModifier:
-  Exclude:
-    - 'app/indexers/year_parser.rb'

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -14,6 +14,7 @@ class WorkIndexer < Hyrax::WorkIndexer
     super.tap do |solr_doc|
       solr_doc['geographic_coordinates_ssim'] = coordinates
       solr_doc['human_readable_rights_statement_tesim'] = human_readable_rights_statement
+      solr_doc['year_isim'] = years
     end
   end
 
@@ -29,5 +30,12 @@ class WorkIndexer < Hyrax::WorkIndexer
       term = rights_terms.find { |entry| entry[:id] == rs }
       term.blank? ? rs : term[:label]
     end
+  end
+
+  # The 'to_a' is needed to force ActiveTriples::Relation to resolve into the String value(s), else you get an error trying to parse the date.
+  def years
+    integer_years = YearParser.integer_years(object.normalized_date.to_a)
+    return nil if integer_years.blank?
+    integer_years
   end
 end

--- a/app/indexers/year_parser.rb
+++ b/app/indexers/year_parser.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class YearParser
+  # @param dates [String, Array<String>] A list of String dates
+  # @return [Array<Integer>] Sorted list of years that correspond to those dates
+  def self.integer_years(dates)
+    Array.wrap(dates).map do |date|
+      if has_a_year?(date)
+        Date.strptime(date, '%Y').year
+      end
+    end.compact.sort
+  end
+
+  # If this string doesn't have 4 numbers in a row, it doesn't contain a 4-digit year.
+  def self.has_a_year?(input_string)
+    four_digit_year = %r{\d{4}}
+    input_string.match?(four_digit_year)
+  end
+end

--- a/app/indexers/year_parser.rb
+++ b/app/indexers/year_parser.rb
@@ -4,16 +4,50 @@ class YearParser
   # @param dates [String, Array<String>] A list of String dates
   # @return [Array<Integer>] Sorted list of years that correspond to those dates
   def self.integer_years(dates)
-    Array.wrap(dates).map do |date|
-      if has_a_year?(date)
-        Date.strptime(date, '%Y').year
-      end
-    end.compact.sort
+    Array.wrap(dates).flat_map do |date|
+      years(date) if maybe_contains_a_year?(date)
+    end.compact.uniq.sort
   end
 
   # If this string doesn't have 4 numbers in a row, it doesn't contain a 4-digit year.
-  def self.has_a_year?(input_string)
+  def self.maybe_contains_a_year?(input_string)
     four_digit_year = %r{\d{4}}
     input_string.match?(four_digit_year)
+  end
+
+  def self.years(input_string)
+    if date_range?(input_string)
+      expand_date(input_string)
+    else
+      parse_year(input_string)
+    end
+  end
+
+  # Check if it's meant to be a range of dates instead of a single date. Examples:
+  #   '1937/1939'
+  #   '1934-06/1934-07'
+  def self.date_range?(input_string)
+    input_string.match?(range_separator)
+  end
+
+  def self.range_separator
+    %r{\/} # a forward slash
+  end
+
+  # If the string is a range of dates instead of a
+  # single date, expand the range into an array of
+  # values.
+  def self.expand_date(input_string)
+    range_start = input_string.match(/^(.*)#{range_separator}/).captures.first
+    range_end = input_string.match(/^.*#{range_separator}(.*)/).captures.first
+
+    starting_year = parse_year(range_start)
+    ending_year = parse_year(range_end)
+
+    (starting_year..ending_year).to_a
+  end
+
+  def self.parse_year(date_string)
+    Date.strptime(date_string, '%Y').year
   end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -55,4 +55,22 @@ RSpec.describe WorkIndexer do
       end
     end
   end
+
+  describe 'integer years for date slider facet' do
+    context 'with a normalized_date' do
+      let(:attributes) { { normalized_date: ['1940-10-15'] } }
+
+      it 'indexes the year' do
+        expect(solr_document['year_isim']).to eq [1940]
+      end
+    end
+
+    context 'when normalized_date field is blank' do
+      let(:attributes) { {} }
+
+      it 'doesn\'t index the year' do
+        expect(solr_document['year_isim']).to eq nil
+      end
+    end
+  end
 end

--- a/spec/indexers/year_parser_spec.rb
+++ b/spec/indexers/year_parser_spec.rb
@@ -5,14 +5,19 @@ RSpec.describe YearParser do
   describe '::integer_years' do
     subject { described_class.integer_years(dates) }
 
+    context 'ISO 8601 date format' do
+      let(:dates) { ['1941-10-01'] }
+      it { is_expected.to eq [1941] }
+    end
+
     context 'just the year' do
       let(:dates) { '1953' }
       it { is_expected.to eq [1953] }
     end
 
-    context 'ISO 8601 date format' do
-      let(:dates) { ['1941-10-01'] }
-      it { is_expected.to eq [1941] }
+    context 'just year and month' do
+      let(:dates) { '1953-10' }
+      it { is_expected.to eq [1953] }
     end
 
     context 'multiple dates' do
@@ -37,6 +42,25 @@ RSpec.describe YearParser do
 
       it 'returns the years that it can parse' do
         expect(parsed_dates).to eq [1953]
+      end
+    end
+
+    context 'ranges of dates' do
+      let(:dates) { ['1937/1939', '1942/1943'] }
+      it { is_expected.to eq [1937, 1938, 1939, 1942, 1943] }
+    end
+
+    context 'date ranges that aren\'t just years' do
+      let(:dates) { '1934-06/1934-07' }
+      it { is_expected.to eq [1934] }
+    end
+
+    context 'duplicate years' do
+      let(:dates) { ['1934-06/1935-07', '1934-06-01', '1934'] }
+      let(:parsed_dates) { subject }
+
+      it 'removes duplcates from the list' do
+        expect(parsed_dates).to eq [1934, 1935]
       end
     end
   end

--- a/spec/indexers/year_parser_spec.rb
+++ b/spec/indexers/year_parser_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe YearParser do
+  describe '::integer_years' do
+    subject { described_class.integer_years(dates) }
+
+    context 'just the year' do
+      let(:dates) { '1953' }
+      it { is_expected.to eq [1953] }
+    end
+
+    context 'ISO 8601 date format' do
+      let(:dates) { ['1941-10-01'] }
+      it { is_expected.to eq [1941] }
+    end
+
+    context 'multiple dates' do
+      let(:unsorted_dates) { ['1941-10-01', '1935', '1945'] }
+      let(:dates) { unsorted_dates }
+      let(:sorted_dates) { subject }
+
+      it 'returns the years in sorted order' do
+        expect(sorted_dates).to eq [1935, 1941, 1945]
+      end
+    end
+
+    context 'when the date field is empty' do
+      let(:dates) { nil }
+      it { is_expected.to eq [] }
+    end
+
+    context 'with an unparseable value' do
+      let(:unparseable) { 'ABCDEF' }
+      let(:dates) { ['1953', unparseable] }
+      let(:parsed_dates) { subject }
+
+      it 'returns the years that it can parse' do
+        expect(parsed_dates).to eq [1953]
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Added an entry to the solr index for the integer years that correspond to the normalized_date field.

* This solr field will be used by Ursus to implement a date slider facet.

* Added a YearParser class that knows how to turn the normalized_date field into a list of integer years. 

Connected to UCLALibrary/ursus#69