### PR TITLE
Added an environment variable to give developer the option to disable spec profiling.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,7 +86,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  config.profile_examples = 10 unless ENV['SKIP_RSPEC_PROFILE'] == 'true'
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
This allows me to reduce visual clutter and avoid unnecessary instrumentation when I'm doing TDD.