### PR TITLE
Replace sass-rails with sassc, mix in font-awesome-sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ gem 'pkg-config', '~> 1.1'
 gem 'mysql2', '~> 0.5'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
@@ -76,8 +74,10 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'fcrepo_wrapper'
   gem 'ffaker'
+  gem 'font-awesome-sass'
   gem 'rspec-rails'
   gem 'rubocop-rspec'
+  gem 'sassc-rails'
   gem 'selenium-webdriver'
   gem 'simplecov', '~> 0.16.1'
   gem 'solr_wrapper', '>= 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,8 @@ GEM
       jquery-rails
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
+    font-awesome-sass (5.5.0.1)
+      sassc (>= 1.11)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     google-api-client (0.24.3)
@@ -724,6 +726,15 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
+    sassc-rails (2.0.0)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     select2-rails (3.5.10)
       thor (~> 0.14)
     selenium-webdriver (3.14.0)
@@ -867,6 +878,7 @@ DEPENDENCIES
   factory_bot_rails
   fcrepo_wrapper
   ffaker
+  font-awesome-sass
   honeybadger (~> 3.1)
   hydra-role-management (~> 1.0.0)
   hyrax (~> 2.2, >= 2.3.3)
@@ -883,7 +895,7 @@ DEPENDENCIES
   rsolr (>= 1.0)
   rspec-rails
   rubocop-rspec
-  sass-rails (~> 5.0)
+  sassc-rails
   selenium-webdriver
   sidekiq (~> 5.1.3)
   sidekiq-failures


### PR DESCRIPTION
- handles Sass deprecation by replacing sass-rails with sassc gem
- adds in font-awesome support via the font-awesome-sass gem

Connected to #321