### PR TITLE
Change header and footer colors to match the Californica Poppy

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -2,13 +2,15 @@ $ucla-blue: #3185c1;
 $ucla-blue-lighter: #c2ddf0;
 $ucla-blue-darker: #24628f;
 
-$navbar-transparent-color: $ucla-blue !default;
+$californica-yellow: #f3c950;
+
+$navbar-transparent-color: $californica-yellow !default;
 $navbar-transparent-bg: rgba(0, 0, 0, 0.6) !default;
-$navbar-transparent-border: $ucla-blue !default;
+$navbar-transparent-border: $californica-yellow !default;
 $navbar-transparent-link-color: $ucla-blue-lighter !default;
 $navbar-transparent-link-hover-color: $ucla-blue-lighter !default;
 $navbar-transparent-link-hover-bg: rgba(255, 255, 255, 0.15) !default;
 $navbar-transparent-link-active-color: $ucla-blue-lighter !default;
 $navbar-transparent-link-active-bg: #585050 !default;
 
-$navbar-default-bg: $ucla-blue !default;
+$navbar-default-bg: $californica-yellow !default;

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -22,16 +22,21 @@
   margin-right: 0.225em;
 }
 
-.navbar-collapse, .navbar-brand, .navbar-header {
-  background: $ucla-blue;
+.navbar-collapse, .navbar-brand, .navbar-header, .site-footer {
+  background: $californica-yellow;
 }
 
 #user_utility_links {
-  background: $ucla-blue;
+  background: $californica-yellow;
+}
+
+.navbar-nav, .nav-item, .nav-link, .searchbar-right label {
+  color: $ucla-blue-darker;
 }
 
 #californica-institution_name {
   font-family: TimesNewRoman,"Times New Roman",Times,Baskerville,Georgia,serif;
   font-weight: bold;
   letter-spacing: 2px;
+  color: $ucla-blue-darker;
 }

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,0 +1,20 @@
+<header>
+  <nav id="masthead" class="navbar navbar-static-top" role="navigation">
+    <div class="container-fluid">
+      <!-- Brand and toggle get grouped for better mobile display -->
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <%= render '/logo' %>
+      </div>
+
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <%= render '/user_util_links' %>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="navbar navbar-inverse site-footer">
+<footer class="navbar site-footer">
   <div class="container-fluid">
     <div class="navbar-text text-left">
         <p><%= t('californica.footer.service_html') %></p>


### PR DESCRIPTION
 - define a new californica_yellow color in _variables.scss
 - use it in the hyrax SCSS
 - revise the footer and masthead templates to stop using the inverse
 navbar styles

 Connected to #325.search-field-header