### PR TITLE
Upgrade solr_wrapper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -759,7 +759,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (4.6.2)
-    solr_wrapper (2.0.0)
+    solr_wrapper (2.1.0)
       faraday
       retriable
       ruby-progressbar


### PR DESCRIPTION
This addresses a bug where the most recent versions of
solr won't download in dev and test environments.