### PR TITLE
Use a CSV to clean records by Item Ark

### DIFF
--- a/app/importers/californica_csv_cleaner.rb
+++ b/app/importers/californica_csv_cleaner.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class CalifornicaCsvCleaner < Darlingtonia::CsvParser
+  ##
+  # @!attribute [rw] error_stream
+  #   @return [#<<]
+  # @!attribute [rw] info_stream
+  #   @return [#<<]
+  attr_accessor :error_stream, :info_stream
+
+  ##
+  # @todo should error_stream and info_stream be moved to the base
+  #   `Darlingtonia::Parser`?
+  #
+  # @param [#<<] error_stream
+  # @param [#<<] info_stream
+  def initialize(file:,
+                 error_stream: Darlingtonia.config.default_error_stream,
+                 info_stream:  Darlingtonia.config.default_info_stream,
+                 **opts)
+    self.error_stream = error_stream
+    self.info_stream  = info_stream
+
+    self.validators = [
+      Darlingtonia::CsvFormatValidator.new(error_stream: error_stream),
+      Darlingtonia::TitleValidator.new(error_stream: error_stream),
+      RightsStatementValidator.new(error_stream: error_stream)
+    ]
+
+    super
+  end
+
+  def clean
+    # use the CalifornicaMapper
+    # Match on ark. For every ark in the file, find the corresponding object
+    # and destroy it.
+    CSV.parse(file.read, headers: true).each_with_index do |row, _index|
+      item = Darlingtonia::InputRecord.from(metadata: row, mapper: CalifornicaMapper.new)
+      ark = item.mapper.metadata["Item Ark"]
+      Work.where(identifier: ark).each do |work|
+        work&.destroy!
+      end
+    end
+
+    # info_stream << "Actually processed #{actual_records_processed} records"
+  rescue CSV::MalformedCSVError
+    # error reporting for this case is handled by validation
+    []
+  end
+end

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -31,6 +31,13 @@ namespace :californica do
       puts Benchmark.measure { CalifornicaImporter.new(csv_file).import }
     end
 
+    desc 'Clean Connell sample data'
+    task clean_connell_sample: [:environment] do
+      csv_file = Rails.root.join('spec', 'fixtures', 'connell_sample.csv')
+      puts "Removing Connell sample data"
+      CalifornicaCsvCleaner.new(file: csv_file).clean
+    end
+
     # Note: This is a super-extra thorough clean out because we were hitting timeout
     # errors. Much of this might be overkill at this point and a simple ActiveFedora::Cleaner.clean!
     # should probably suffice in most development environments.

--- a/spec/importers/californica_csv_cleaner_spec.rb
+++ b/spec/importers/californica_csv_cleaner_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CalifornicaCsvCleaner do
+  subject(:cleaner) { described_class.new(file: file) }
+  let(:file)        { File.open(csv_path) }
+  let(:csv_path)    { 'spec/fixtures/example.csv' }
+  let(:work)        { FactoryBot.create(:work, identifier: ["21198/zz0002nq4w"]) }
+  let(:other_work)  { FactoryBot.create(:work, identifier: ["21198/zz0002nq4zzz"]) }
+
+  describe 'when we need to reingest', :clean do
+    before do
+      work
+      other_work
+    end
+    it 'removes all objects matching the unique id in a CSV file' do
+      expect(Work.count).to eq 2
+      cleaner.clean
+      expect(Work.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Given a CSV with an Item Ark column, find any records
with the given arks and destroy them.

This will let us selectively re-ingest parts of the collection
as we benchmark test performance.