### PR TITLE
Remove fits.log and avoid accidentally checking it in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+*.log
 !/log/.keep
 !/tmp/.keep
 


### PR DESCRIPTION
FITS tends to leave a log file in the home directory that we don't need to have checked into the repo.