### PR TITLE
Add a single value Ark to the Solr index

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -16,6 +16,7 @@ class WorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_rights_statement_tesim'] = human_readable_rights_statement
       solr_doc['year_isim'] = years
       solr_doc['identifier_ssim'] = object.identifier
+      solr_doc['ark_ssi'] = get_ark_from_identifier(object.identifier)
     end
   end
 
@@ -39,4 +40,9 @@ class WorkIndexer < Hyrax::WorkIndexer
     return nil if integer_years.blank?
     integer_years
   end
+
+  def get_ark_from_identifier(identifiers=[])
+    identifiers.find { |id| id.include?("ark:/") }
+  end
+
 end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -41,8 +41,7 @@ class WorkIndexer < Hyrax::WorkIndexer
     integer_years
   end
 
-  def get_ark_from_identifier(identifiers=[])
+  def get_ark_from_identifier(identifiers = [])
     identifiers.find { |id| id.include?("ark:/") }
   end
-
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -82,4 +82,13 @@ RSpec.describe WorkIndexer do
       expect(solr_document['identifier_ssim']).to contain_exactly('123', '456')
     end
   end
+
+  describe 'ark' do
+    let(:attributes) { { identifier: ['123', 'ark:/67531/metadc1213294/', '456'] } }
+
+    # To be able use the ark as the Blacklight identifier we need it to be a single value string.
+    it 'indexes as a single value "string"' do
+      expect(solr_document['ark_ssi']).to eq 'ark:/67531/metadc1213294/'
+    end
+  end
 end


### PR DESCRIPTION
Connected to #358 

ARKs are available as a single-valued field for blacklight  

This requires us to add the "ark:/ " prefix to all identifiers in the  
+ local development environment
+ sample data
+ test, dev and stage and environments
+ production environments

And then re-index

---

Changes to be committed:
+ modified:   app/indexers/work_indexer.rb
+ modified:   spec/indexers/work_indexer_spec.rb