### PR TITLE
set default config values to match docker-compose.yml

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,9 +1,9 @@
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/hydra-development" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/californica" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_TEST_URL'] || "http://127.0.0.1:8985/solr/hydra-test" %>
+  url: <%= ENV['SOLR_TEST_URL'] || "http://127.0.0.1:8985/solr/californica" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,11 @@
 default: &default
-  adapter:      <%= ENV['DATABASE_ADAPTER'] || 'mysql2' %>
-  pool:         <%= ENV['DATABASE_POOL'] || 5 %>
-  timeout:      5000
-  host:         <%= ENV['DATABASE_HOST'] || 'localhost' %>
+  adapter: <%= ENV['DATABASE_ADAPTER'] || 'mysql2' %>
+  pool: <%= ENV['DATABASE_POOL'] || 5 %>
+  timeout: 5000
+  host: <%= ENV['DATABASE_HOST'] || '127.0.0.1' %>
   min_messages: <%= ENV['DATABASE_MIN_MESSAGES'] || 'warning' %>
-  username:     <%= ENV['DATABASE_USERNAME'] || 'californica' %>
-  password:     <%= ENV['DATABASE_PASSWORD'] %>
-
+  username: <%= ENV['DATABASE_USERNAME'] || 'californica' %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>
 
 development:
   <<: *default
@@ -21,6 +20,6 @@ test:
 
 production:
   <<: *default
-  adapter:  'mysql2'
+  adapter: "mysql2"
   database: <%= ENV['DATABASE_NAME'] %>
-  pool:     <%= ENV['DATABASE_POOL'] || 20 %>
+  pool: <%= ENV['DATABASE_POOL'] || 20 %>

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,6 +1,6 @@
 development:
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/hydra-development" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/californica" %>
 test:
-  url: <%= ENV['SOLR_TEST_URL'] || "http://127.0.0.1:8985/solr/hydra-test" %>
+  url: <%= ENV['SOLR_TEST_URL'] || "http://127.0.0.1:8985/solr/californica" %>
 production:
   url: <%= ENV['SOLR_URL'] %>

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -3,6 +3,6 @@ port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp/solr_downloads
 collection:
-    persist: false
-    dir: solr/config
-    name: hydra-test
+  persist: false
+  dir: solr/config
+  name: californica


### PR DESCRIPTION
These changes allow a hybrid dev environment where rails runs natively
on the host system, but connects to backing services run in docker.