### PR TITLE
Make ARK available to blacklight as single-value field

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -16,7 +16,7 @@ class WorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_rights_statement_tesim'] = human_readable_rights_statement
       solr_doc['year_isim'] = years
       solr_doc['identifier_ssim'] = object.identifier
-      solr_doc['ark_ssi'] = get_ark_from_identifier(object.identifier)
+      solr_doc['ark_ssi'] = ark
     end
   end
 
@@ -41,7 +41,12 @@ class WorkIndexer < Hyrax::WorkIndexer
     integer_years
   end
 
-  def get_ark_from_identifier(identifiers = [])
-    identifiers.find { |id| id.include?("ark:/") }
+  def ark
+    return if object.identifier.blank?
+    if object.identifier.first.start_with?('ark:/')
+      object.identifier.first
+    else
+      "ark:/" + object.identifier.first
+    end
   end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -84,11 +84,19 @@ RSpec.describe WorkIndexer do
   end
 
   describe 'ark' do
-    let(:attributes) { { identifier: ['123', 'ark:/67531/metadc1213294/', '456'] } }
+    let(:attributes) { { identifier: ['123/456'] } }
 
     # To be able use the ark as the Blacklight identifier we need it to be a single value string.
     it 'indexes as a single value "string"' do
-      expect(solr_document['ark_ssi']).to eq 'ark:/67531/metadc1213294/'
+      expect(solr_document['ark_ssi']).to eq 'ark:/123/456'
+    end
+  end
+
+  describe 'ark' do
+    let(:attributes) { { identifier: ['ark:/123/456'] } }
+
+    it 'does not duplicate the "ark:/"' do
+      expect(solr_document['ark_ssi']).to eq 'ark:/123/456'
     end
   end
 end


### PR DESCRIPTION
Add "ark:/" on the value in the solr index if it doesn't already exist

---

On branch single-value-ark_399

Changes to be committed:
+ modified:   app/indexers/work_indexer.rb
+ deleted:    lib/tasks/.keep
+ modified:   spec/indexers/work_indexer_spec.rb