### PR TITLE
Address security issue in bootstrap-sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'pkg-config', '~> 1.1'
 # Error reporting tool
 gem 'rollbar'
 
+gem "bootstrap-sass", ">= 3.4.1"
 # Use mysql
 gem 'mysql2', '~> 0.5'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       rails (>= 4.2, < 6)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.1.3)
+    autoprefixer-rails (9.4.9)
       execjs
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
@@ -115,9 +115,9 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     bootstrap_form (2.7.0)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (0.15.1)
@@ -595,8 +595,8 @@ GEM
     rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rdf (3.0.10)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -714,7 +714,7 @@ GEM
     rubyzip (1.2.2)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
-    sass (3.5.7)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -725,6 +725,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
     select2-rails (3.5.10)
       thor (~> 0.14)
     selenium-webdriver (3.14.0)
@@ -849,6 +852,7 @@ PLATFORMS
 
 DEPENDENCIES
   bixby (~> 1.0.0)
+  bootstrap-sass (>= 3.4.1)
   byebug
   capistrano (~> 3.11)
   capistrano-bundler (~> 1.3)


### PR DESCRIPTION
CVE-2019-8331
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is
possible in the tooltip or popover data-template attribute. For more
information, see:
https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/