### PR TITLE
Allow deploy to ubuntu servers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -80,17 +80,6 @@ end
 # This creates the default admin user
 after 'deploy:published', 'rails:rake:db:seed'
 
-# Capistrano passenger restart isn't working consistently,
-# so restart apache2 after a successful deploy, to ensure
-# changes are picked up.
-namespace :deploy do
-  after :finishing, :restart_apache do
-    on roles(:app) do
-      execute :sudo, :systemctl, :restart, :httpd
-    end
-  end
-end
-
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/config/deploy/californica-dev.rb
+++ b/config/deploy/californica-dev.rb
@@ -1,2 +1,12 @@
 # frozen_string_literal: true
 server 'californica-dev.library.ucla.edu', user: 'deploy', roles: [:web, :app, :db]
+# Capistrano passenger restart isn't working consistently,
+# so restart apache2 after a successful deploy, to ensure
+# changes are picked up.
+namespace :deploy do
+  after :finishing, :restart_apache do
+    on roles(:app) do
+      execute :sudo, :systemctl, :restart, :httpd
+    end
+  end
+end

--- a/config/deploy/californica-stage.rb
+++ b/config/deploy/californica-stage.rb
@@ -1,2 +1,12 @@
 # frozen_string_literal: true
 server 'californica-stage.library.ucla.edu', user: 'deploy', roles: [:web, :app, :db]
+# Capistrano passenger restart isn't working consistently,
+# so restart apache2 after a successful deploy, to ensure
+# changes are picked up.
+namespace :deploy do
+  after :finishing, :restart_apache do
+    on roles(:app) do
+      execute :sudo, :systemctl, :restart, :httpd
+    end
+  end
+end

--- a/config/deploy/cd.rb
+++ b/config/deploy/cd.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-# Deploy to continuous deployment server
-server 'cd-ucla.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/dce-qa.rb
+++ b/config/deploy/dce-qa.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
-server 'californica-test.library.ucla.edu', user: 'deploy', roles: [:web, :app, :db]
+# Deploy to continuous deployment server
+server 'californica-qa.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]
 # Capistrano passenger restart isn't working consistently,
 # so restart apache2 after a successful deploy, to ensure
 # changes are picked up.
 namespace :deploy do
   after :finishing, :restart_apache do
     on roles(:app) do
-      execute :sudo, :systemctl, :restart, :httpd
+      execute :sudo, :systemctl, :restart, :apache2
     end
   end
 end

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -1,2 +1,0 @@
-# frozen_string_literal: true
-server 'demo-ucla.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,2 +1,0 @@
-# frozen_string_literal: true
-server 'sandbox-ucla.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]


### PR DESCRIPTION
For performance testing we need to be able to deploy to DCE
infrastructure, which is ubuntu-based. Accordingly, we need to move any
Red Hat specific capistrano commands into their specific deploy
environments, and add ubuntu-specific commands into *their* specific
deploy environments.

In other words, run `sudo systemctl restart apache2` when deploying to
ubuntu, and `sudo systemctl restart httpd` when deploying to Red Hat.