### PR TITLE
Pared down update stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ end
 
 ruby '>= 2.4.0', '<= 2.5.99'
 
-gem 'darlingtonia', '>= 3.1.1'
+# gem 'darlingtonia', '>= 3.1.1'
+gem "darlingtonia", github: "curationexperts/darlingtonia", branch: "pared_down_update_stack"
 
 gem 'hyrax', '~> 2.2', '>= 2.3.3'
 gem 'rails', '~> 5.1.6'

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ end
 
 ruby '>= 2.4.0', '<= 2.5.99'
 
-# gem 'darlingtonia', '>= 3.1.1'
-gem "darlingtonia", github: "curationexperts/darlingtonia", branch: "pared_down_update_stack"
+gem 'darlingtonia', '>= 3.2.0'
 
 gem 'hyrax', '~> 2.2', '>= 2.3.3'
 gem 'rails', '~> 5.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/curationexperts/darlingtonia.git
-  revision: 1ca6367b5ce5532b8bfb3ad0e6d6cd7f2fd5d1ef
-  branch: pared_down_update_stack
-  specs:
-    darlingtonia (3.1.1)
-      active-fedora (>= 11.5.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -196,6 +188,8 @@ GEM
       thor
     crass (1.0.4)
     daemons (1.3.1)
+    darlingtonia (3.2.0)
+      active-fedora (>= 11.5.2)
     database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -870,7 +864,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   coveralls
-  darlingtonia!
+  darlingtonia (>= 3.2.0)
   database_cleaner
   devise
   devise-guests (~> 0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/curationexperts/darlingtonia.git
+  revision: 1ca6367b5ce5532b8bfb3ad0e6d6cd7f2fd5d1ef
+  branch: pared_down_update_stack
+  specs:
+    darlingtonia (3.1.1)
+      active-fedora (>= 11.5.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -188,8 +196,6 @@ GEM
       thor
     crass (1.0.4)
     daemons (1.3.1)
-    darlingtonia (3.1.1)
-      active-fedora (>= 11.5.2)
     database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -864,7 +870,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   coveralls
-  darlingtonia (>= 3.1.1)
+  darlingtonia!
   database_cleaner
   devise
   devise-guests (~> 0.6)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,7 +48,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('subject', :facetable), limit: 5
     config.add_facet_field solr_name('language', :facetable), limit: 5
     config.add_facet_field solr_name('file_format', :facetable), limit: 5
-    config.add_facet_field solr_name('member_of_collection_ids', :symbol), limit: 5, label: 'Collections', helper_method: :collection_title_by_id
+    config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collection'
     config.add_facet_field solr_name('repository', :facetable), limit: 5
     config.add_facet_field solr_name('normalized_date', :facetable), label: 'Normalized Date', limit: 5
     config.add_facet_field solr_name('named_subject', :facetable), label: 'Names', limit: 5

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,7 +58,6 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('extent', :facetable), label: 'Extent', limit: 5
     config.add_facet_field solr_name('genre', :facetable), label: 'Genre', limit: 5
     config.add_facet_field solr_name('location', :facetable), label: 'Location', limit: 5
-    config.add_facet_field solr_name('dlcs_collection_name', :facetable), label: 'DLCS Collection Name', limit: 5
 
     # The generic_type isn't displayed on the facet list
     # It's used to give a label to the filter that comes from the user profile

--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -40,20 +40,12 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
   def records
     return enum_for(:records) unless block_given?
     file.rewind
-    actual_records_processed = 0
-    expected_records_processed = 0
-
     # use the CalifornicaMapper
     CSV.parse(file.read, headers: true).each_with_index do |row, index|
       next unless index >= skip
       next if row.to_h.values.all?(&:nil?)
       yield Darlingtonia::InputRecord.from(metadata: row, mapper: CalifornicaMapper.new)
-      actual_records_processed += 1
-      expected_records_processed = index + 1 # index starts with 0, we want to start with 1
     end
-
-    info_stream << "Expected #{expected_records_processed} records"
-    info_stream << "Actually processed #{actual_records_processed} records"
   rescue CSV::MalformedCSVError
     # error reporting for this case is handled by validation
     []

--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -24,14 +24,8 @@ class CalifornicaImporter
       deduplication_field: DEDUPLICATION_FIELD
     }
 
-    start_time = Time.zone.now
-    @info_stream << "Beginning ingest process at #{start_time}"
     record_importer = ActorRecordImporter.new(error_stream: @error_stream, info_stream: @info_stream, attributes: attrs)
-    Darlingtonia::Importer.new(parser: parser, record_importer: record_importer).import if parser.validate
-    end_time = Time.zone.now
-    elapsed_time = end_time - start_time
-    @info_stream << "Finished ingest process at #{end_time}"
-    @info_stream << "Elapsed time: #{elapsed_time}"
+    Darlingtonia::Importer.new(parser: parser, record_importer: record_importer, info_stream: @info_stream, error_stream: @error_stream).import if parser.validate
   end
 
   def parser

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -38,6 +38,12 @@ namespace :californica do
       CalifornicaCsvCleaner.new(file: csv_file).clean
     end
 
+    desc 'Remove data indicated by CSV_FILE'
+    task clean: [:environment] do
+      puts "Removing data indicated by CSV_FILE"
+      CalifornicaCsvCleaner.new(file: CSV_FILE).clean
+    end
+
     # Note: This is a super-extra thorough clean out because we were hitting timeout
     # errors. Much of this might be overkill at this point and a simple ActiveFedora::Cleaner.clean!
     # should probably suffice in most development environments.
@@ -62,7 +68,7 @@ namespace :californica do
       end
     end
 
-    desc "Ingest a collection -- Use CSV_FILE and IMPORT_FILE_PATH to specify data locations."
+    desc "Ingest a collection -- Use CSV_FILE and IMPORT_FILE_PATH to specify data locations and COLLECTION_ID to indicate collection membership."
     task csv: :environment do
       unless CSV_FILE && IMPORT_FILE_PATH
         puts "Specify import parameters like this: CSV_FILE=/path/to/file.csv IMPORT_FILE_PATH=/path/to/files/ COLLECTION_ID=abc123 bundle exec rake californica:ingest"

--- a/spec/features/import_and_show_work_spec.rb
+++ b/spec/features/import_and_show_work_spec.rb
@@ -73,7 +73,6 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
       expect(page).to have_content "No linguistic content" # language
       expect(page).to have_content "Famous Photographer" # photographer
       expect(page).to have_content "34.05707, -118.239577" # geographic_coordinates, a.k.a. latitude and longitude
-      expect(page).to have_content "DLCS Collection Name"
       expect(page).to have_content "Los Angeles Daily News Negatives. Department of Special Collections, Charles E. Young Research Library, University of California at Los Angeles." # relation.isPartOf
     end
     it "displays expected fields on search results page" do
@@ -90,6 +89,6 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
     importer.import
     visit("/catalog?search_field=all_fields&q=")
     facet_headings = page.all(:css, 'h3.facet-field-heading/a').to_a.map(&:text)
-    expect(facet_headings).to contain_exactly("Subject", "Resource type", "Genre", "Names", "Location", "Normalized Date", "Extent", "Medium", "Dimensions", "Language", "DLCS Collection Name")
+    expect(facet_headings).to contain_exactly("Subject", "Resource type", "Genre", "Names", "Location", "Normalized Date", "Extent", "Medium", "Dimensions", "Language")
   end
 end

--- a/spec/features/import_and_show_work_spec.rb
+++ b/spec/features/import_and_show_work_spec.rb
@@ -89,6 +89,6 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
     importer.import
     visit("/catalog?search_field=all_fields&q=")
     facet_headings = page.all(:css, 'h3.facet-field-heading/a').to_a.map(&:text)
-    expect(facet_headings).to contain_exactly("Subject", "Resource type", "Genre", "Names", "Location", "Normalized Date", "Extent", "Medium", "Dimensions", "Language")
+    expect(facet_headings).to contain_exactly("Subject", "Resource type", "Genre", "Names", "Location", "Normalized Date", "Extent", "Medium", "Dimensions", "Language", "Collection")
   end
 end

--- a/spec/importers/californica_csv_parser_spec.rb
+++ b/spec/importers/californica_csv_parser_spec.rb
@@ -3,9 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe CalifornicaCsvParser do
-  subject(:parser) { described_class.new(file: file) }
-  let(:file)       { File.open(csv_path) }
-  let(:csv_path)   { 'spec/fixtures/example.csv' }
+  subject(:parser)    { described_class.new(file: file) }
+  let(:file)          { File.open(csv_path) }
+  let(:csv_path)      { 'spec/fixtures/example.csv' }
+  let(:info_stream)   { [] }
+  let(:error_stream)  { [] }
 
   after do
     ENV['SKIP'] = '0'
@@ -15,7 +17,7 @@ RSpec.describe CalifornicaCsvParser do
     include_context 'with workflow'
 
     let(:importer) do
-      Darlingtonia::Importer.new(parser: parser, record_importer: ActorRecordImporter.new)
+      Darlingtonia::Importer.new(parser: parser, record_importer: ActorRecordImporter.new, info_stream: info_stream, error_stream: error_stream)
     end
 
     it 'imports records' do

--- a/spec/importers/californica_importer_spec.rb
+++ b/spec/importers/californica_importer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CalifornicaImporter, :clean do
 
     it "records the time it took to ingest" do
       importer.import
-      expect(File.readlines(importer.ingest_log_filename).each(&:chomp!).last).to match(/Elapsed time/)
+      expect(File.readlines(importer.ingest_log_filename).each(&:chomp!).last).to match(/elapsed_time/)
     end
 
     it "records the number of records ingested" do

--- a/spec/importers/californica_importer_spec.rb
+++ b/spec/importers/californica_importer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CalifornicaImporter, :clean do
 
     it "records the number of records ingested" do
       importer.import
-      expect(File.read(importer.ingest_log_filename)).to match(/Actually processed 1 records/)
+      expect(File.read(importer.ingest_log_filename)).to match(/successful_record_count: 1/)
     end
 
     context 'when the image file is missing' do


### PR DESCRIPTION
* Metadata-only update when the deduplication field
matches an existing record. That means it will not try to re-import
attached files, it will only update metadata and collection membership.

* Redirect logging in tests for better performance.

* Remove temporary text-only collection facet.

* Pass logging locations to DarlingtoniaImporter so success and
failure counts go to the same log location as everywhere else.

* Remove `elapsed_time` reporting from Californica in favor of the reporting now contained in Darlingtonia 

Connected to #403 
Connected to https://github.com/UCLALibrary/amalgamated-samvera/issues/275
