### PR TITLE
Update the predicate for Local Identifier

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -101,7 +101,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('funding_note', :stored_searchable)
     config.add_show_field solr_name('genre', :stored_searchable)
     config.add_show_field solr_name('location', :stored_searchable)
-    config.add_show_field solr_name('local_identifier', :stored_searchable)
+    config.add_show_field 'local_identifier_ssm'
     config.add_show_field solr_name('medium', :stored_searchable)
     config.add_show_field solr_name('named_subject', :stored_searchable)
     config.add_show_field solr_name('normalized_date', :stored_searchable)
@@ -127,7 +127,7 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
     config.add_search_field('all_fields', label: 'All Fields') do |field|
-      search_fields = 'title_tesim subject_tesim named_subject_tesim location_tesim description_tesim caption_tesim identifier_tesim local_identifier_tesim normalized_date_tesim photographer_tesim'
+      search_fields = 'title_tesim subject_tesim named_subject_tesim location_tesim description_tesim caption_tesim identifier_tesim local_identifier_sim normalized_date_tesim photographer_tesim'
 
       field.solr_parameters = {
         qf: search_fields,

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -63,7 +63,7 @@ class SolrDocument
   end
 
   def local_identifier
-    self[Solrizer.solr_name('local_identifier')]
+    self[:local_identifier_ssm]
   end
 
   def longitude

--- a/app/models/ucla_metadata.rb
+++ b/app/models/ucla_metadata.rb
@@ -35,8 +35,8 @@ module UclaMetadata
       index.as :stored_searchable, :facetable
     end
 
-    property :local_identifier, predicate: ::RDF::Vocab::DC11.identifier do |index|
-      index.as :stored_searchable
+    property :local_identifier, predicate: ::RDF::Vocab::Identifiers.local do |index|
+      index.as :displayable, :facetable
     end
 
     property :longitude, predicate: ::RDF::Vocab::EXIF.gpsLongitude do |index|

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Collection do
   it "has local_identifier" do
     collection.local_identifier = ['local_identifier']
     expect(collection.local_identifier).to include 'local_identifier'
-    expect(collection.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/identifier/)
+    expect(collection.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/identifiers\/local/)
   end
 
   it "has funding_note" do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Work do
   it "has local_identifier" do
     work.local_identifier = ['local_identifier']
     expect(work.local_identifier).to include 'local_identifier'
-    expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/identifier/)
+    expect(work.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/identifiers\/local/)
   end
 
   it "has funding_note" do


### PR DESCRIPTION
* the local_identifier property is stored in the predicate
::RDF::Vocab::Identifiers.local

* local identifiers are not tokenized

Connected to https://github.com/UCLALibrary/californica/issues/435