### PR TITLE
docker: persist /opt/derivatives and /opt/uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     volumes:
       - .:/californica
       - ./data:/opt/data
+      - derivatives:/opt/derivatives
+      - uploads:/opt/uploads
       - bundle_dir:/usr/local/bundle
       - log:/californica/log
       - tmp:/californica/tmp
@@ -96,9 +98,11 @@ services:
 
 volumes:
   bundle_dir:
+  derivatives:
   fcrepo_data:
   log:
   mysql_data:
   redis_data:
   solr_data:
   tmp:
+  uploads:


### PR DESCRIPTION
Needed for e.g. thumbnails.

connected to https://github.com/UCLALibrary/ursus/issues/239