### PR TITLE
Add metadata to collection view

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -2,6 +2,11 @@
 module Hyrax
   module Dashboard
     module CollectionsControllerOverride
+      def self.prepended(_base)
+        Hyrax::CollectionsController.presenter_class = Hyrax::CalifornicaCollectionPresenter
+        Hyrax::Dashboard::CollectionsController.presenter_class = Hyrax::CalifornicaCollectionPresenter
+      end
+
       # Use the local CalifornicaCollectionsForm, which includes all of the UCLA Metadata fields
       def form_class
         Hyrax::CalifornicaCollectionsForm

--- a/app/presenters/hyrax/californica_collection_presenter.rb
+++ b/app/presenters/hyrax/californica_collection_presenter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Hyrax
+  class CalifornicaCollectionPresenter < Hyrax::CollectionPresenter
+    # Terms is the list of fields displayed by
+    # app/views/collections/_show_descriptions.html.erb
+    def self.terms
+      [
+        :total_items, :size, :resource_type, :creator, :contributor,
+        :keyword, :license, :publisher, :date_created, :subject,
+        :language, :identifier, :based_near, :related_url,
+        :extent, :caption,
+        :dimensions, :funding_note, :genre,
+        :latitude, :longitude,
+        :local_identifier, :medium,
+        :named_subject, :normalized_date,
+        :repository, :location,
+        :rights_country, :rights_holder, :photographer
+      ]
+    end
+  end
+end

--- a/spec/features/show_collection_spec.rb
+++ b/spec/features/show_collection_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Show a collection', :clean do
+  let(:collection) { Collection.create!(collection_attrs) }
+  let(:collection) { FactoryBot.create(:collection_lw, user: admin) }
+  let(:admin) { FactoryBot.create :admin }
+
+  let(:collection_attrs) do
+    {
+      title: ['Old Title'],
+      rights_statement: ['http://rightsstatements.org/vocab/InC/1.0/'], # "copyrighted"
+      publisher: ['Old Pub'],
+      date_created: ['Old Creation Date'],
+      subject: ['Old Subj'],
+      language: ['Old Lang'],
+      description: ['Old Desc'],
+      resource_type: ['Image'],
+      extent: ['Old Extent'],
+      caption: ['Old Cap'],
+      dimensions: ['Old Dim'],
+      funding_note: ['Old Fund Note'],
+      genre: ['Old Genre'],
+      latitude: ['Old Lat'],
+      longitude: ['Old Long'],
+      local_identifier: ['Old Local ID'],
+      medium: ['Old Medium'],
+      named_subject: ['Old Name/Subj'],
+      normalized_date: ['Old Normalized Date'],
+      repository: ['Old Repository'],
+      location: ['Old Loc'],
+      rights_country: ['Old Rights Country'],
+      rights_holder: ['Old Rights Holder'],
+      photographer: ['Old Photographer']
+    }
+  end
+
+  include_context 'with workflow'
+
+  before do
+    # Set all the attributes of collection
+    # Normally we'd do this in the FactoryBot factory, but in this case we want
+    # to use the Hyrax factories.
+    collection_attrs.each do |k, v|
+      collection.send((k.to_s + "=").to_sym, v)
+    end
+    collection.save
+  end
+
+  context 'the collection owner' do
+    scenario 'sees all expected metadata for the collection on the public view' do
+      login_as admin
+
+      visit "/collections/#{collection.id}?locale=en"
+      expect(page).to have_content collection.title.first
+
+      collection_attrs.delete(:rights_statement) # Rights Statement display is a special case
+      collection_attrs.each_value do |v|
+        expect(page).to have_content v.first
+      end
+    end
+
+    scenario 'sees all expected metadata for the collection on the dashboard view' do
+      login_as admin
+
+      visit "/dashboard/collections/#{collection.id}?locale=en"
+      expect(page).to have_content collection.title.first
+
+      collection_attrs.delete(:rights_statement) # Rights Statement display is a special case
+      collection_attrs.each_value do |v|
+        expect(page).to have_content v.first
+      end
+    end
+  end
+end

--- a/spec/features/show_collection_spec.rb
+++ b/spec/features/show_collection_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.feature 'Show a collection', :clean do
-  let(:collection) { Collection.create!(collection_attrs) }
   let(:collection) { FactoryBot.create(:collection_lw, user: admin) }
   let(:admin) { FactoryBot.create :admin }
 


### PR DESCRIPTION
When UCLA metadata is added to a collection object, it should also
appear on the show view for that collection.

Connected to #431 