### PR TITLE
docker: run bundle check || bundle install when starting web container

### DIFF
--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+bundle check || bundle install
+
 bundle exec sidekiq &
 
 find . -name *.pid -delete


### PR DESCRIPTION
Needed because the docker-compose setup keeps a local cache of gems
that occasionally needs to be updated.