### PR TITLE
Add a route to get branding info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 .env.production
 .env.test
 coverage
+
+public/branding/

--- a/app/controllers/branding_info_controller.rb
+++ b/app/controllers/branding_info_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class BrandingInfoController < ApplicationController
+  respond_to :json
+  def show
+    @banner_info = CollectionBrandingInfo.where(collection_id: params[:id])[0]
+    respond_with @banner_info
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  get 'branding_info/:id', to: 'branding_info#show', as: 'branding_info'
+
   root 'catalog#index'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'

--- a/spec/controllers/branding_info_controller_spec.rb
+++ b/spec/controllers/branding_info_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe BrandingInfoController, type: :controller do
+  let(:collection_branding_info) { CollectionBrandingInfo.new(filename: 'test.png', collection_id: '3039530', role: 'banner') }
+  describe "GET #show" do
+    it "returns http success" do
+      collection_branding_info
+      get :show, params: { id: '3039530', format: 'json' }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
The data about where the collection banner is stored in the Californica database (not Fedora/Solr).

This adds a route and controller so that we can access
this data from ursus.

Connected to UCLALibrary/ursus#257