### PR TITLE
Prevent  searches from being saved to the database

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,6 +15,7 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
+    config.crawler_detector = ->(_req) { true }
     config.view.gallery.partials = %i[index_header index]
     config.view.masonry.partials = [:index]
     config.view.slideshow.partials = [:index]

--- a/spec/features/search_crawler_spec.rb
+++ b/spec/features/search_crawler_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "Search History Page", :clean do
+  describe "crawler search" do
+    it "doesn't remember human searches" do
+      visit root_path
+      fill_in "q", with: 'cat'
+      expect { click_button 'Go' }.not_to change { Search.count }
+    end
+
+    it "doesn't remember bot searches", :clean do
+      page.driver.header('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+      visit root_path
+      fill_in "q", with: 'cat'
+      expect { click_button 'Go' }.not_to change { Search.count }
+    end
+  end
+end


### PR DESCRIPTION
**`config/schedule.rb:25`**
```
rake "blacklight:delete_old_searches[1]"
```

This PR will replace the need for this scheduled rake task.:

---

Changes to be committed:
+ modified:   app/controllers/catalog_controller.rb
+ new file:   spec/features/search_crawler_spec.rb

Connected to UCLALibrary/amalgamated-samvera#287