### PR TITLE
Delete rule in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,8 @@ Layout/MultilineBlockLayout:
 Layout/BlockEndNewline:
   Exclude:
     - 'spec/features/search_catalog_spec.rb'
+
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/tasks/**/*'
+    - 'spec/features/search_crawler_spec.rb'


### PR DESCRIPTION
Deleted this rule about the DescribeClass because it is unimportant.

```
Offenses:

spec/features/search_crawler_spec.rb:4:16: C: RSpec/DescribeClass: The first argument to describe should be the class or module being tested.
RSpec.describe "Search History Page", :clean do
               ^^^^^^^^^^^^^^^^^^^^^

137 files inspected, 1 offense detected
```

Connected to https://github.com/UCLALibrary/amalgamated-samvera/issues/287