### PR TITLE
Implement a read-only mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   helper Openseadragon::OpenseadragonHelper
   # Adds a few additional behaviors into the application controller
@@ -9,7 +10,24 @@ class ApplicationController < ActionController::Base
   # Adds Hyrax behaviors into the application controller
   include Hyrax::Controller
   include Hyrax::ThemedLayoutController
+
+  # Check to see if we're in read_only mode
+  before_action :check_read_only, except: [:show, :index]
+
   with_themed_layout '1_column'
 
   protect_from_forgery with: :exception
+
+  # What to do if read_only mode has been enabled, via FlipFlop
+  # If read_only is enabled, redirect any requests that would allow
+  # changes to the system. This is to enable easier migrations.
+  def check_read_only
+    return unless Flipflop.read_only?
+    # Exempt the FlipFlop controller itself from read_only mode, so it can be turned off
+    return if self.class.to_s == Hyrax::Admin::StrategiesController.to_s
+    redirect_back(
+      fallback_location: root_path,
+      alert: "This system is in read-only mode for maintenance. No submissions or edits can be made at this time."
+    )
+  end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled. This will create a safe window during which backups can be performed.
+
+Flipflop.configure do
+  feature :read_only,
+          default: false,
+          description: "Put the system into read-only mode disabling changes and uploads."
+end

--- a/spec/features/read_only_mode_spec.rb
+++ b/spec/features/read_only_mode_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Read Only Mode' do
+  let(:user)  { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create :admin }
+
+  context 'a logged in user' do
+    before { login_as admin }
+
+    scenario "View Works", js: false do
+      # read-only off
+      visit("/concern/works/new")
+      expect(page).to have_content("Requirements")
+      allow(Flipflop).to receive(:read_only?).and_return(true)
+      # read-only on
+      visit("/concern/works/new")
+      expect(page).to have_content("This system is in read-only mode for maintenance. No submissions or edits can be made at this time.")
+      expect(page).to_not have_content("Requirements")
+      # read-only off
+      allow(Flipflop).to receive(:read_only?).and_return(false)
+      visit("/concern/works/new")
+      expect(page).to have_content("Requirements")
+    end
+  end
+end


### PR DESCRIPTION
### Creates a read-only mode for Californica  
which creates a safe window during which backups can be performed. 

When californica is in read-only mode it can still be searched  
and ursus will will be able to read from californica,  
but no changes can be made. 

+ There is a feature flipper that will turn the `read only` mode on and off
<img width="913" alt="Screen Shot 2019-03-20 at 10 23 20 AM" src="https://user-images.githubusercontent.com/751697/54709954-df9b6900-4b03-11e9-8a9a-f6f00c8f08ea.png">

+ When read-only mode is in effect there is a banner telling Users why they can't add or edit records
<img width="1090" alt="Screen Shot 2019-03-20 at 11 04 05 AM" src="https://user-images.githubusercontent.com/751697/54709926-cc889900-4b03-11e9-9130-ad8e79784dd9.png">



---

Changes to be committed:
+ modified:   app/controllers/application_controller.rb
+ new file:   config/features.rb
+ new file:   spec/features/read_only_mode_spec.rb