### PR TITLE
Fix intermittent CI failure

### DIFF
--- a/spec/features/read_only_mode_spec.rb
+++ b/spec/features/read_only_mode_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Read Only Mode' do
+RSpec.feature 'Read Only Mode', :clean do
   let(:user)  { FactoryBot.create(:user) }
   let(:admin) { FactoryBot.create :admin }
 


### PR DESCRIPTION
This fixes an intermittent CI failure that was throwing this error:

 ActiveRecord::RecordNotFound:
   Couldn't find Hyrax::CollectionType matching GID 'gid://californica/hyrax-collectiontype/9'