### PR TITLE
Convert to system specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/LineLength:
   Exclude:
     - 'spec/tasks/ingest_spec.rb'
     - 'app/importers/rights_statement_validator.rb'
-    - 'spec/features/import_and_show_work_spec.rb'
+    - 'spec/system/import_and_show_work_spec.rb'
     - app/importers/actor_record_importer.rb
 
 Metrics/MethodLength:
@@ -34,39 +34,39 @@ Metrics/MethodLength:
     - app/importers/actor_record_importer.rb
     - app/forms/hyrax/californica_collections_form.rb
 
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/tasks/**/*'
-
 RSpec/ExampleLength:
   Enabled: true
   Exclude:
-    - 'spec/features**/*'
+    - 'spec/system**/*'
     - 'spec/tasks/ingest_spec.rb'
     - 'spec/importers/californica_mapper_spec.rb'
     - 'spec/importers/californica_importer_spec.rb'
+
+RSpec/LetSetup:
+  Enabled: false
 
 RSpec/NotToNot:
   Enabled: false
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/features/search_catalog_spec.rb'
+    - 'spec/system/search_catalog_spec.rb'
     - 'spec/importers/californica_importer_spec.rb'
 
 Style/BlockDelimiters:
   Exclude:
-    - 'spec/features/search_catalog_spec.rb'
+    - 'spec/system/search_catalog_spec.rb'
 
 Layout/MultilineBlockLayout:
   Exclude:
-    - 'spec/features/search_catalog_spec.rb'
+    - 'spec/system/search_catalog_spec.rb'
 
 Layout/BlockEndNewline:
   Exclude:
-    - 'spec/features/search_catalog_spec.rb'
+    - 'spec/system/search_catalog_spec.rb'
 
 RSpec/DescribeClass:
   Exclude:
     - 'spec/tasks/**/*'
-    - 'spec/features/search_crawler_spec.rb'
+    - 'spec/system/search_crawler_spec.rb'
+    - 'spec/tasks/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - gem install bundler:1.17.3
 before_script:
   - bundle exec rake db:create
-  - bundle exec rake db:create
   - ln --symbolic /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -67,11 +67,10 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
-  gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'fcrepo_wrapper'
   gem 'ffaker'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 3.8'
   gem 'rubocop-rspec'
   gem 'selenium-webdriver'
   gem 'simplecov', '~> 0.16.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,6 @@ GEM
     crass (1.0.4)
     darlingtonia (3.2.0)
       active-fedora (>= 11.5.2)
-    database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deprecation (1.0.0)
@@ -863,7 +862,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   coveralls
   darlingtonia (>= 3.2.0)
-  database_cleaner
   devise
   devise-guests (~> 0.6)
   dotenv-rails (~> 2.2.1)
@@ -885,7 +883,7 @@ DEPENDENCIES
   riiif (~> 1.1)
   rollbar
   rsolr (>= 1.0)
-  rspec-rails
+  rspec-rails (~> 3.8)
   rubocop-rspec
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/spec/support/shared_contexts/workflow.rb
+++ b/spec/support/shared_contexts/workflow.rb
@@ -14,6 +14,5 @@ RSpec.shared_context 'with workflow' do
 
   after do
     ActiveFedora::Cleaner.clean!
-    DatabaseCleaner.clean
   end
 end

--- a/spec/system/create_work_spec.rb
+++ b/spec/system/create_work_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 require 'rails_helper'
-require 'database_cleaner'
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Work', js: true do
-  DatabaseCleaner.strategy = :truncation
-  DatabaseCleaner.start
-
+RSpec.describe 'Create a Work', type: :system, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }

--- a/spec/system/create_work_spec.rb
+++ b/spec/system/create_work_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.describe 'Create a Work', type: :system, js: true do
+RSpec.describe 'Create a Work', :clean, type: :system, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Edit an existing collection', :clean do
+RSpec.describe 'Edit an existing collection', :clean, type: :system, js: false do
   let(:collection) { Collection.create!(collection_attrs) }
   let(:collection) { FactoryBot.create(:collection_lw, user: admin) }
   let(:admin) { FactoryBot.create :admin }
@@ -59,6 +59,7 @@ RSpec.feature 'Edit an existing collection', :clean do
       expect(find_field('Title').value).to eq 'Old Title'
       # expect(page.all(:css, 'div.select.work_rights_statement/select').first.text).to eq 'copyrighted'
       expect(first(:css, '#collection_description').value).to eq 'Old Desc'
+      click_on 'Additional fields'
       expect(find_field('Publisher').value).to eq 'Old Pub'
       expect(find_field('Date Created').value).to eq 'Old Creation Date'
       expect(find_field('Subject').value).to eq 'Old Subj'

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Edit an existing collection', :clean, type: :system, js: false do
+RSpec.describe 'Edit an existing collection', :clean, type: :system, js: true do
   let(:collection) { Collection.create!(collection_attrs) }
   let(:collection) { FactoryBot.create(:collection_lw, user: admin) }
   let(:admin) { FactoryBot.create :admin }

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Edit an existing work', :clean, type: :system, js: false do
+RSpec.describe 'Edit an existing work', :clean, type: :system, js: true do
   let(:work) { Work.create!(work_attrs) }
 
   let(:work_attrs) do

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Edit an existing work', :clean do
+RSpec.describe 'Edit an existing work', :clean, type: :system, js: false do
   let(:work) { Work.create!(work_attrs) }
 
   let(:work_attrs) do
     {
       title: ['Old Title'],
-      rights_statement: ['http://rightsstatements.org/vocab/InC/1.0/'], # "copyrighted"
+      ark: 'ark:/abc/3456',
+      rights_statement: ['http://vocabs.library.ucla.edu/rights/copyrighted'], # "copyrighted"
       publisher: ['Old Pub'],
       date_created: ['Old Creation Date'],
       subject: ['Old Subj'],
@@ -44,10 +45,11 @@ RSpec.feature 'Edit an existing work', :clean do
 
     scenario 'successfully edits the work' do
       visit edit_hyrax_work_path(work.id)
-
       # When the form first loads, it should contain all the old values
       expect(find_field('Title').value).to eq 'Old Title'
-      expect(page.all(:css, 'div.select.work_rights_statement/select').first.text).to eq 'copyrighted'
+      expect(find_field('Ark').value).to eq 'ark:/abc/3456'
+      expect(page.all(:css, 'div.select.work_rights_statement').first.has_content?('copyrighted')).to eq true
+      click_on 'Additional fields'
       expect(first(:css, '#work_description').value).to eq 'Old Desc'
       expect(find_field('Publisher').value).to eq 'Old Pub'
       expect(find_field('Date Created').value).to eq 'Old Creation Date'

--- a/spec/system/import_and_show_work_spec.rb
+++ b/spec/system/import_and_show_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Import and Display a Work', :clean, js: false do
+RSpec.describe 'Import and Display a Work', :clean, type: :system, js: false do
   subject(:importer) { CalifornicaImporter.new(file, depositor_id: user.user_key) }
   let(:file)       { File.open(csv_file) }
   let(:csv_file)   { File.join(fixture_path, 'coordinates_example.csv') }
@@ -55,7 +55,7 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
       expect(page).to have_content "Historic buildings--California--Los Angeles" # $subject: $z has been replaced with --
       expect(page).to have_content "still image" # resource_type
       expect(page).to have_content "copyrighted" # rights_statement
-      expect(page).not_to have_css('li.attribute-rights_statement/a') # Rights statement should not link anywhere
+      expect(page).not_to have_link "copyrighted" # Rights statement should not link anywhere
       expect(page).to have_content "news photographs" # genre
       expect(page).to have_content "Plaza Church (Los Angeles, Calif.)" # named_subject
       expect(page).to have_content "University of California, Los Angeles. Library. Department of Special Collections" # repository
@@ -88,7 +88,7 @@ RSpec.feature 'Import and Display a Work', :clean, js: false do
   it "displays expected facets" do
     importer.import
     visit("/catalog?search_field=all_fields&q=")
-    facet_headings = page.all(:css, 'h3.facet-field-heading/a').to_a.map(&:text)
+    facet_headings = page.all(:css, 'h3.facet-field-heading').to_a.map(&:text)
     expect(facet_headings).to contain_exactly("Subject", "Resource type", "Genre", "Names", "Location", "Normalized Date", "Extent", "Medium", "Dimensions", "Language", "Collection")
   end
 end

--- a/spec/system/import_and_show_work_spec.rb
+++ b/spec/system/import_and_show_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Import and Display a Work', :clean, type: :system, js: false do
+RSpec.describe 'Import and Display a Work', :clean, type: :system, js: true do
   subject(:importer) { CalifornicaImporter.new(file, depositor_id: user.user_key) }
   let(:file)       { File.open(csv_file) }
   let(:csv_file)   { File.join(fixture_path, 'coordinates_example.csv') }

--- a/spec/system/read_only_mode_spec.rb
+++ b/spec/system/read_only_mode_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Read Only Mode', :clean, type: :system, js: false do
+RSpec.describe 'Read Only Mode', :clean, type: :system, js: true do
   let(:user)  { FactoryBot.create(:user) }
   let(:admin) { FactoryBot.create :admin }
 

--- a/spec/system/read_only_mode_spec.rb
+++ b/spec/system/read_only_mode_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Read Only Mode', :clean do
+RSpec.describe 'Read Only Mode', :clean, type: :system, js: false do
   let(:user)  { FactoryBot.create(:user) }
   let(:admin) { FactoryBot.create :admin }
 

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -1,37 +1,41 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.feature 'Search the catalog', :clean do
+RSpec.describe 'Search the catalog', :clean, type: :system, js: false do
   # Create works with unique values for each field.
   # This metadata is contrived so we can test different types of searches.
 
-  let!(:banana) { Work.create!(
-    title: ['Yellow Banana'],
-    visibility: visible,
-    subject: ['fruit'],
-    named_subject: ['dessert'],
-    location: ['on the table'],
-    description: ['potassium'],
-    caption: ['tropical'],
-    identifier: ['ban_ark'],
-    local_identifier: ['12345'],
-    normalized_date: ['2015-10-06'],
-    photographer: ['Sherlock']
-  ) }
+  let!(:banana) do
+    Work.create!(
+      title: ['Yellow Banana'],
+      visibility: visible,
+      subject: ['fruit'],
+      named_subject: ['dessert'],
+      location: ['on the table'],
+      description: ['potassium'],
+      caption: ['tropical'],
+      identifier: ['ban_ark'],
+      local_identifier: ['12345'],
+      normalized_date: ['2015-10-06'],
+      photographer: ['Sherlock']
+    )
+  end
 
-  let!(:carrot) { Work.create!(
-    title: ['Orange Carrot'],
-    visibility: visible,
-    subject: ['veg'],
-    named_subject: ['side dish'],
-    location: ['in the fridge'],
-    description: ['beta carotene'],
-    caption: ['northern'],
-    identifier: ['car_ark'],
-    local_identifier: ['67890'],
-    normalized_date: ['2018-07-07'],
-    photographer: ['Watson']
-  ) }
+  let!(:carrot) do
+    Work.create!(
+      title: ['Orange Carrot'],
+      visibility: visible,
+      subject: ['veg'],
+      named_subject: ['side dish'],
+      location: ['in the fridge'],
+      description: ['beta carotene'],
+      caption: ['northern'],
+      identifier: ['car_ark'],
+      local_identifier: ['67890'],
+      normalized_date: ['2018-07-07'],
+      photographer: ['Watson']
+    )
+  end
 
   let(:visible) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
 

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'Search the catalog', :clean, type: :system, js: false do
+RSpec.describe 'Search the catalog', :clean, type: :system, js: true do
   # Create works with unique values for each field.
   # This metadata is contrived so we can test different types of searches.
 

--- a/spec/system/search_crawler_spec.rb
+++ b/spec/system/search_crawler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "Search History Page", :clean, type: :system, js: false do
+RSpec.describe "Search History Page", :clean, type: :system, js: true do
   describe "crawler search" do
     it "doesn't remember human searches" do
       visit root_path

--- a/spec/system/search_crawler_spec.rb
+++ b/spec/system/search_crawler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "Search History Page", :clean do
+RSpec.describe "Search History Page", :clean, type: :system, js: false do
   describe "crawler search" do
     it "doesn't remember human searches" do
       visit root_path
@@ -9,8 +9,7 @@ RSpec.describe "Search History Page", :clean do
       expect { click_button 'Go' }.not_to change { Search.count }
     end
 
-    it "doesn't remember bot searches", :clean do
-      page.driver.header('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+    it "doesn't remember bot searches", :clean, driver: :googlebot do
       visit root_path
       fill_in "q", with: 'cat'
       expect { click_button 'Go' }.not_to change { Search.count }

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Show a collection', :clean do
+RSpec.describe 'Show a collection', :clean, type: :system, js: false do
   let(:collection) { FactoryBot.create(:collection_lw, user: admin) }
   let(:admin) { FactoryBot.create :admin }
 

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Show a collection', :clean, type: :system, js: false do
+RSpec.describe 'Show a collection', :clean, type: :system, js: true do
   let(:collection) { FactoryBot.create(:collection_lw, user: admin) }
   let(:admin) { FactoryBot.create :admin }
 

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Display a Work', type: :system, js: false do
+RSpec.describe 'Display a Work', type: :system, js: true do
   let(:work) { FactoryBot.create(:work) }
   let(:admin) { FactoryBot.create(:admin) }
 

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Display a Work', js: false do
+RSpec.describe 'Display a Work', type: :system, js: false do
   let(:work) { FactoryBot.create(:work) }
   let(:admin) { FactoryBot.create(:admin) }
 


### PR DESCRIPTION
Convert to system tests instead of feature tests to give us more
stability around javascript testing and eliminate the need for database
cleaner, which has also been giving us intermittent problems.

This should make it easier to test the edit form.

Connected to https://github.com/UCLALibrary/californica/issues/456