### PR TITLE
Ark values are not editable

### DIFF
--- a/app/forms/hyrax/californica_collections_form.rb
+++ b/app/forms/hyrax/californica_collections_form.rb
@@ -12,6 +12,16 @@ module Hyrax
 
     self.required_fields = [:title, :ark]
 
+    # Make some fields read-only
+    def readonly?(field)
+      readonly_fields = [:ark]
+      # If there is no value set already, allow it to be set the first time
+      return false if send(field).empty?
+      # If a readonly field has a value set already, do not allow it to be edited
+      return true if readonly_fields.include?(field)
+      false
+    end
+
     # Terms that appear above the accordion
     def primary_terms
       [:title, :ark, :description]

--- a/app/forms/hyrax/work_form.rb
+++ b/app/forms/hyrax/work_form.rb
@@ -14,5 +14,15 @@ module Hyrax
                    :rights_country, :rights_holder, :photographer]
 
     self.required_fields = [:title, :ark, :rights_statement]
+
+    # Make some fields read-only
+    def readonly?(field)
+      readonly_fields = [:ark]
+      # If there is no value set already, allow it to be set the first time
+      return false if send(field).empty?
+      # If a readonly field has a value set already, do not allow it to be edited
+      return true if readonly_fields.include?(field)
+      false
+    end
   end
 end

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key), readonly: f.object.readonly?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key), readonly: f.object.readonly?(key) %>
+<% end %>

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe 'Edit an existing work', :clean, type: :system, js: true do
       # Edit some fields in the form
       fill_in 'Title', with: 'New Title'
       fill_in 'Dimensions', with: 'New Dim'
+      fill_in 'Ark', with: 'ark:/not/myark' # This field is read-only and an attempt to change it should not result in a change
 
       # Submit the form.  When the page reloads, it should be on the show page.
       click_on 'Save changes'
@@ -86,6 +87,8 @@ RSpec.describe 'Edit an existing work', :clean, type: :system, js: true do
       expect(page).to_not have_content 'Old Title'
       expect(page).to     have_content 'New Dim'
       expect(page).to_not have_content 'Old Dim'
+      expect(page).to     have_content 'ark:/abc/3456'
+      expect(page).to_not have_content 'ark:/not/myark'
     end
   end
 end


### PR DESCRIPTION
Allow an Ark to be set via the new work form, but once an object has an
ark do not allow it to be edited from the form -- make it readonly.

Connected to #456 