### PR TITLE
Refactored code for readability

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -45,6 +45,11 @@ class CalifornicaMapper < Darlingtonia::HashMapper
       ['masterImageName', 'Parent ARK', 'Project Name']
   end
 
+  # What columns must exist in the CSV
+  def self.required_headers
+    ['Title', 'Item Ark']
+  end
+
   def fields
     CALIFORNICA_TERMS_MAP.keys + [:remote_files, :visibility, :member_of_collections_attributes]
   end

--- a/app/importers/csv_validator.rb
+++ b/app/importers/csv_validator.rb
@@ -21,7 +21,7 @@ class CsvValidator < Darlingtonia::Validator
   end
 
   def required_headers
-    ['Title', 'Item Ark']
+    CalifornicaMapper.required_headers
   end
 
   def allowed_headers


### PR DESCRIPTION
For validating the CSV file, we have required headers and allowed
headers.  I thought it was awkward that the required headers were in the
validator class, and the allowed headers were in the mapper class.  So,
I moved the required headers over to the mapper.  In the future, if a
developer needs to add a new column to the CSV file, they'll have to
edit the mapper, so it makes sense to put the required/allowed headers
near the place the new columns will go.

Connected to #481