### PR TITLE
Assign primary identifiers based on ark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'sidekiq', '~> 5.1.3'
 gem 'sidekiq-failures'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+# gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'uglifier', '>= 1.3.0' # Use Uglifier as compressor for JavaScript assets
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -894,7 +894,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   whenever

--- a/app/actors/hyrax/actors/work_actor.rb
+++ b/app/actors/hyrax/actors/work_actor.rb
@@ -4,6 +4,13 @@
 module Hyrax
   module Actors
     class WorkActor < Hyrax::Actors::BaseActor
+      def apply_save_data_to_curation_concern(env)
+        raise "Cannot set id without a valid ark" unless env.attributes["ark"]
+        ark_based_id = Californica::IdGenerator.id_from_ark(env.attributes["ark"])
+        env.curation_concern.id = ark_based_id unless env.curation_concern.id
+        env.curation_concern.attributes = clean_attributes(env.attributes)
+        env.curation_concern.date_modified = TimeService.time_in_utc
+      end
     end
   end
 end

--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -11,6 +11,28 @@ module Hyrax
       def form_class
         Hyrax::CalifornicaCollectionsForm
       end
+
+      # Override #create method from Hyrax to assign an ark based identifier to any newly created collection objects
+      def create
+        # Manual load and authorize necessary because Cancan will pass in all
+        # form attributes. When `permissions_attributes` are present the
+        # collection is saved without a value for `has_model.`
+        @collection = ::Collection.new
+        authorize! :create, @collection
+        # Coming from the UI, a collection type gid should always be present.  Coming from the API, if a collection type gid is not specified,
+        # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)
+        @collection.collection_type_gid = params[:collection_type_gid].presence || default_collection_type.gid
+        @collection.id = Californica::IdGenerator.id_from_ark(collection_params["ark"])
+        @collection.attributes = collection_params.except(:members, :parent_id, :collection_type_gid)
+        @collection.apply_depositor_metadata(current_user.user_key)
+        add_members_to_collection unless batch.empty?
+        @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
+        if @collection.save
+          after_create
+        else
+          after_create_error
+        end
+      end
     end
   end
 end

--- a/app/lib/californica/id_generator.rb
+++ b/app/lib/californica/id_generator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Californica
+  module IdGenerator
+    # Take an ark value and return a valid fedora identifier
+    def self.id_from_ark(ark)
+      split = ark.split('/')
+      shoulder = split[-2]
+      blade = split[-1]
+      "#{blade}-#{shoulder}"
+    end
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -21,6 +21,7 @@ class Collection < ActiveFedora::Base
     return collection if collection
 
     collection = Collection.create(
+      id: Californica::IdGenerator.id_from_ark(ark),
       title: ["Collection #{ark}"],
       ark: ark,
       collection_type: Hyrax::CollectionType.find_or_create_default_collection_type,

--- a/spec/importers/actor_record_importer_spec.rb
+++ b/spec/importers/actor_record_importer_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe ActorRecordImporter, :clean do
     {
       'Title' => 'Comet in Moominland',
       'language' => 'English',
-      'visibility' => 'open'
+      'visibility' => 'open',
+      'Item Ark' => 'ark:/abc/123'
     }
   end
 
@@ -36,7 +37,8 @@ RSpec.describe ActorRecordImporter, :clean do
       let(:metadata) do
         {
           'Title' => 'Comet in Moominland',
-          'masterImageName' => "clusc_1_1_00010432a.tif"
+          'masterImageName' => "clusc_1_1_00010432a.tif",
+          'Item Ark' => "ark:/abc/1234"
         }
       end
 
@@ -49,7 +51,10 @@ RSpec.describe ActorRecordImporter, :clean do
 
     context 'with an invalid input record' do
       let(:metadata) do
-        { 'visibility' => 'open' }
+        {
+          'visibility' => 'open',
+          'Item Ark' => 'ark:/abc/123'
+        }
       end
 
       it 'logs an error' do

--- a/spec/importers/californica_importer_spec.rb
+++ b/spec/importers/californica_importer_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe CalifornicaImporter, :clean do
     end
 
     context 'when the collection doesn\'t exist yet' do
+      it 'creates a new collection with a modified ark as the id' do
+        importer.import
+        new_collection = Collection.first
+        expect(new_collection.id).to eq "zz00294nz8-21198"
+      end
       it 'creates a new collection and adds the work to it' do
         expect(Collection.count).to eq 0
         expect(Work.count).to eq 0

--- a/spec/lib/californica/id_generator_spec.rb
+++ b/spec/lib/californica/id_generator_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Californica::IdGenerator, :clean do
+  let(:ark) { 'ark:/13030/t8dn9c0x' }
+  it 'makes a fedora id from an ark' do
+    id = Californica::IdGenerator.id_from_ark(ark)
+    expect(id).to eq 't8dn9c0x-13030'
+  end
+end

--- a/spec/system/create_work_spec.rb
+++ b/spec/system/create_work_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe 'Create a Work', :clean, type: :system, js: true do
       expect(page).to have_content('My Test Work')
       expect(page).to have_content("ark:/abc/123")
       expect(page).to have_content("Your files are being processed")
+      work = Work.last
+      expect(work.id).to eq '123-abc'
     end
   end
 end

--- a/spec/system/import_and_show_work_spec.rb
+++ b/spec/system/import_and_show_work_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Import and Display a Work', :clean, type: :system, js: true do
     it "displays expected fields on show work page" do
       importer.import
       work = Work.last
+      expect(work.id).to eq "hb338nb26f-13030"
       visit("/concern/works/#{work.id}")
       expect(page).to have_content "Communion at Plaza Church, Los Angeles, 1942-1952" # title
       expect(page).to have_content "ark:/13030/hb338nb26f" # ark

--- a/spec/system/new_collection_spec.rb
+++ b/spec/system/new_collection_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Create a new collection', :clean, type: :system, js: true do
   context 'logged in as an admin user' do
     before { login_as admin }
 
-    scenario 'successfully edits the work' do
+    scenario 'successfully creates a new collection with an ark based identifier' do
       visit "/dashboard/my/collections"
       click_on 'New Collection'
       choose('User Collection')
@@ -29,6 +29,8 @@ RSpec.describe 'Create a new collection', :clean, type: :system, js: true do
       expect(page).to have_content title
       expect(find_field('Ark').value).to eq ark
       expect(page).to have_content 'Collection was successfully created.'
+      collection = Collection.last
+      expect(collection.id).to eq '1234-abc'
     end
   end
 end


### PR DESCRIPTION
If a work does not have an identifier, give it one based on its ark
value. Raise an error if it doesn't have an ark to use for this purpose.

Connected to #492 