### PR TITLE
Reduce memory usage when running with Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,16 +43,21 @@ services:
       - "8984:8080"
     volumes:
       - fcrepo_data:/data
+    environment:
+      JAVA_OPTIONS: "-Xmx512m"
 
   fedora_test:
     image: nulib/fcrepo4:4.7.5
     ports:
       - "8986:8080"
+    environment:
+      JAVA_OPTIONS: "-Xmx512m"
 
   db:
     image: mysql:5.6
     volumes:
       - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./docker/conf.d:/etc/mysql/conf.d
       - mysql_data:/var/lib/mysql
     ports:
       - "3306:3306"

--- a/docker/conf.d/mysql.cnf
+++ b/docker/conf.d/mysql.cnf
@@ -1,0 +1,32 @@
+[mysql]
+default_character_set = utf8
+
+[mysqld]
+character_set_server = utf8
+collation_server = utf8_general_ci
+
+innodb_buffer_pool_size=5M
+innodb_log_buffer_size=256K
+query_cache_size=0
+max_connections=10
+key_buffer_size=8
+thread_cache_size=0
+host_cache_size=0
+innodb_ft_cache_size=1600000
+innodb_ft_total_cache_size=32000000
+
+# per thread or per operation settings
+thread_stack=131072
+sort_buffer_size=32K
+read_buffer_size=8200
+read_rnd_buffer_size=8200
+max_heap_table_size=16K
+tmp_table_size=1K
+bulk_insert_buffer_size=0
+join_buffer_size=128
+net_buffer_length=1K
+innodb_sort_buffer_size=64K
+
+#settings that relate to the binary log (if enabled)
+binlog_cache_size=4K
+binlog_stmt_cache_size=4K


### PR DESCRIPTION
I normally run the application on a Linux host
which doesn't require a VM. I tried running
californica on a Windows host (which uses a VM)
and needed to increase the default ram used by
the VM from 2GB to 8GB to get the test suite to run.

These changes will reduce the amount of memory used by
Fedora and MySQL so that users on non-Linux systems
will use less ram.