### PR TITLE
Add a warning to read-only mode

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -5,5 +5,5 @@
 Flipflop.configure do
   feature :read_only,
           default: false,
-          description: "Put the system into read-only mode disabling changes and uploads."
+          description: "Put the system into read-only mode disabling changes and uploads. Do not close this session before re-enabling read/write -- you will not be able to login."
 end


### PR DESCRIPTION
Warn someone who is enabling read-only mode that they need to leave
their window open because they won't be able to create a new session
once read-only mode is on.

Connected to https://github.com/UCLALibrary/californica/issues/547