### PR TITLE
Do not truncate the ARK in import logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'bootstrap-sass', ">= 3.4.1"
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 gem 'coveralls', require: false
-gem 'darlingtonia', '>= 3.2.0'
+gem 'darlingtonia', '>= 3.2.2'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'dotenv-rails', '~> 2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
       thor (~> 0.19.4)
       tins (~> 1.6)
     crass (1.0.4)
-    darlingtonia (3.2.0)
+    darlingtonia (3.2.2)
       active-fedora (>= 11.5.2)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -861,7 +861,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   coveralls
-  darlingtonia (>= 3.2.0)
+  darlingtonia (>= 3.2.2)
   devise
   devise-guests (~> 0.6)
   dotenv-rails (~> 2.2.1)


### PR DESCRIPTION
Upgrade Darlingtonia to 3.2.2, which fixes a bug where it was assuming
that the deduplication field would always be a multi-valued field.
Because we are using ARK as our deduplication field, and it is not
multi-valued, this was causing arks to be truncated in our import logs.

Connected to #537 