### PR TITLE
Use exact case in create_new_work spec

### DIFF
--- a/spec/system/create_work_spec.rb
+++ b/spec/system/create_work_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Create a Work', :clean, type: :system, js: true do
       # choose "payload_concern", option: "Work"
       # click_button "Create work"
 
-      expect(page).to have_content "Add New Work"
+      expect(page).to have_content "Add new work"
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"


### PR DESCRIPTION
Depending on the environment you run tests in (and the drivers used
by capybara), tests for text on pages may or may not be case sensistive.

I've been getting the error:

Failures:

  1) Create a Work a logged in user should text "Add New Work"
     Failure/Error: expect(page).to have_content "Add New Work"
       expected to find text "Add New Work" in v"Californica Switch language... ". (However, it was found 1 time using a case insensitive search.)

The text actually rendered to the page is "Add new work" instead of "Add New Work"