### PR TITLE
Index a stripped down ARK for use in ursus

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -2,4 +2,9 @@
 
 # Include any special UCLA Collection indexing here
 class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc['ursus_id_ssi'] = Californica::IdGenerator.blacklight_id_from_ark(object.ark)
+    end
+  end
 end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -15,6 +15,7 @@ class WorkIndexer < Hyrax::WorkIndexer
       solr_doc['geographic_coordinates_ssim'] = coordinates
       solr_doc['human_readable_rights_statement_tesim'] = human_readable_rights_statement
       solr_doc['year_isim'] = years
+      solr_doc['ursus_id_ssi'] = Californica::IdGenerator.blacklight_id_from_ark(object.ark)
     end
   end
 

--- a/app/lib/californica/id_generator.rb
+++ b/app/lib/californica/id_generator.rb
@@ -3,7 +3,12 @@ module Californica
   module IdGenerator
     # Take an ark value and return a valid fedora identifier
     def self.id_from_ark(ark)
-      id = ark.gsub(/ark:?\/?/, '')
+      blacklight_id_from_ark(ark).reverse
+    end
+
+    # Take an ark value and return an identifier that can be used in blacklight catalog controllers
+    def self.blacklight_id_from_ark(ark)
+      id = ark.gsub(/\s+/, "").gsub(/ark:?\/?/, '')
       shoulder, blade, extension = id.split('/')
 
       # didn't see {shoulder}/{blade} format ark
@@ -11,7 +16,7 @@ module Californica
       # looks like an extended ark
       raise ArgumentError, 'ARK appears to have too many segments or extensions' unless extension.nil?
 
-      "#{shoulder}-#{blade}".reverse
+      "#{shoulder}-#{blade}"
     end
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -8,6 +8,8 @@ class Collection < ActiveFedora::Base
   include Hyrax::BasicMetadata
   self.indexer = ::CollectionIndexer
 
+  validates :ark, presence: { message: 'Your Collection must have an ARK.' }
+
   # @param ark [String] The ARK
   # @return [Collection] The Collection with that ARK
   def self.find_by_ark(ark)

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -8,6 +8,7 @@ class Work < ActiveFedora::Base
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
+  validates :ark, presence: { message: 'Your Work must have an ARK.' }
 
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -105,6 +105,7 @@ FactoryBot.define do
     sequence(:title) { |n| ["Collection #{n}"] }
     visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     collection_type { Hyrax::CollectionType.find_or_create_default_collection_type }
+    sequence(:ark, 1_234_567) { |n| "ark:/99999/#{n}" }
   end
 
   factory :collection_lw, class: Collection do
@@ -117,6 +118,7 @@ FactoryBot.define do
       with_solr_document { false }
     end
     sequence(:title) { |n| ["Collection Title #{n}"] }
+    sequence(:ark, 1_234_567) { |n| "ark:/aaaaa/#{n}" }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -12,5 +12,9 @@ RSpec.describe ::CollectionIndexer do
     it 'add the fields to the solr document' do
       expect(solr_document['ark_ssi']).to eq 'ark:/123/456'
     end
+
+    it 'indexes a simplified id for ursus' do
+      expect(solr_document['ursus_id_ssi']).to eq '123-456'
+    end
   end
 end

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe WorkIndexer do
 
   describe 'rights statement' do
     context 'a work with a rights statement' do
-      let(:attributes) { { rights_statement: ['http://vocabs.library.ucla.edu/rights/copyrighted'] } }
+      let(:attributes) do
+        {
+          ark: 'ark:/123/456',
+          rights_statement: ['http://vocabs.library.ucla.edu/rights/copyrighted']
+        }
+      end
 
       it 'indexes a human-readable rights statement' do
         expect(solr_document['human_readable_rights_statement_tesim']).to eq ['copyrighted']
@@ -19,7 +24,12 @@ RSpec.describe WorkIndexer do
     # but if it does, handle it gracefully.
     context 'when there is no human-readable value' do
       let(:no_match) { "a rights statement that doesn't have a matching value in config/authorities/rights_statements.yml" }
-      let(:attributes) { { rights_statement: [no_match, 'http://vocabs.library.ucla.edu/rights/copyrighted'] } }
+      let(:attributes) do
+        {
+          ark: 'ark:/123/456',
+          rights_statement: [no_match, 'http://vocabs.library.ucla.edu/rights/copyrighted']
+        }
+      end
 
       it 'just returns the original value' do
         expect(solr_document['human_readable_rights_statement_tesim']).to contain_exactly(no_match, 'copyrighted')
@@ -30,8 +40,11 @@ RSpec.describe WorkIndexer do
   describe 'latitude and longitude' do
     context 'a work with latitude and longitude' do
       let(:attributes) do
-        { latitude: ['45.0'],
-          longitude: ['-93.0'] }
+        {
+          ark: 'ark:/123/456',
+          latitude: ['45.0'],
+          longitude: ['-93.0']
+        }
       end
 
       it 'indexes the coordinates in a single field' do
@@ -40,7 +53,12 @@ RSpec.describe WorkIndexer do
     end
 
     context 'a work that is missing latitude' do
-      let(:attributes) { { longitude: ['-93.0'] } }
+      let(:attributes) do
+        {
+          ark: 'ark:/123/456',
+          longitude: ['-93.0']
+        }
+      end
 
       it 'doesn\'t index the coordinates' do
         expect(solr_document['geographic_coordinates_ssim']).to eq nil
@@ -48,7 +66,12 @@ RSpec.describe WorkIndexer do
     end
 
     context 'a work that is missing longitude' do
-      let(:attributes) { { latitude: ['45.0'] } }
+      let(:attributes) do
+        {
+          ark: 'ark:/123/456',
+          latitude: ['45.0']
+        }
+      end
 
       it 'doesn\'t index the coordinates' do
         expect(solr_document['geographic_coordinates_ssim']).to eq nil
@@ -58,7 +81,12 @@ RSpec.describe WorkIndexer do
 
   describe 'integer years for date slider facet' do
     context 'with a normalized_date' do
-      let(:attributes) { { normalized_date: ['1940-10-15'] } }
+      let(:attributes) do
+        {
+          ark: 'ark:/123/456',
+          normalized_date: ['1940-10-15']
+        }
+      end
 
       it 'indexes the year' do
         expect(solr_document['year_isim']).to eq [1940]
@@ -66,7 +94,11 @@ RSpec.describe WorkIndexer do
     end
 
     context 'when normalized_date field is blank' do
-      let(:attributes) { {} }
+      let(:attributes) do
+        {
+          ark: 'ark:/123/456'
+        }
+      end
 
       it 'doesn\'t index the year' do
         expect(solr_document['year_isim']).to eq nil
@@ -75,18 +107,18 @@ RSpec.describe WorkIndexer do
   end
 
   describe 'ark' do
-    let(:attributes) { { ark: 'ark:/123/456' } }
+    let(:attributes) do
+      {
+        ark: 'ark:/123/456'
+      }
+    end
 
-    it 'indexes as a single value "string"' do
+    it 'indexes as a single value "string" without duplicating the prefix ("ark:/ark:/")' do
       expect(solr_document['ark_ssi']).to eq 'ark:/123/456'
     end
-  end
 
-  describe 'ark' do
-    let(:attributes) { { ark: 'ark:/123/456' } }
-
-    it 'does not duplicate the "ark:/"' do
-      expect(solr_document['ark_ssi']).to eq 'ark:/123/456'
+    it 'indexes a simplified id for ursus' do
+      expect(solr_document['ursus_id_ssi']).to eq '123-456'
     end
   end
 end

--- a/spec/lib/californica/id_generator_spec.rb
+++ b/spec/lib/californica/id_generator_spec.rb
@@ -6,7 +6,13 @@ RSpec.describe Californica::IdGenerator, :clean do
   let(:extended_ark) { 'ark:/13030/t8dn9c0x/001' }
   let(:old_school) { '13030/t8dn9c0x' }
   let(:wonky_ark) { 'ark:13030/t8dn9c0x' }
+  let(:spacey_ark) { ' ark:13030 / t8dn9c0x ' }
   let(:non_ark) { 'this is not an ark' }
+
+  it 'makes a blacklight id from an ark' do
+    id = Californica::IdGenerator.blacklight_id_from_ark(ark)
+    expect(id).to eq '13030-t8dn9c0x'
+  end
 
   it 'makes a fedora id from an ark' do
     id = Californica::IdGenerator.id_from_ark(ark)
@@ -20,6 +26,11 @@ RSpec.describe Californica::IdGenerator, :clean do
 
   it 'has relaxed rules about prefixes' do
     id = Californica::IdGenerator.id_from_ark(wonky_ark)
+    expect(id).to eq 'x0c9nd8t-03031'
+  end
+
+  it 'removes whitespace from ids' do
+    id = Californica::IdGenerator.id_from_ark(spacey_ark)
     expect(id).to eq 'x0c9nd8t-03031'
   end
 

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Show a collection', :clean, type: :system, js: true do
   let(:collection_attrs) do
     {
       title: ['Old Title'],
-      ark: 'ark:/abc/123456',
       rights_statement: ['http://rightsstatements.org/vocab/InC/1.0/'], # "copyrighted"
       publisher: ['Old Pub'],
       date_created: ['Old Creation Date'],
@@ -58,8 +57,7 @@ RSpec.describe 'Show a collection', :clean, type: :system, js: true do
 
       collection_attrs.delete(:rights_statement) # Rights Statement display is a special case
 
-      ark_value = collection_attrs.delete(:ark)
-      expect(page).to have_content ark_value
+      expect(page).to have_content collection.ark
 
       collection_attrs.each_value do |v|
         expect(page).to have_content v.first

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'hyrax/base/attributes.html.erb', type: :view do
   let(:solr_document) { SolrDocument.new(work.to_solr) }
   let(:work)          do
     Work.new(title: ['title'],
+             ark: 'ark:/abcde/1234567',
              description: ['description'],
              extent: ['extent'],
              caption: ['caption'], dimensions: ['dimensions'],


### PR DESCRIPTION
Given an ARK like 'ark:/abcdef/1234567', update the solr index to include
an `catalog_id_ssi` like 'abcdef-1234567' that can be used as the
primary identifer in blacklight applications like ursus.