### PR TITLE
CSV cleaner should destroy and eradicate objects CAL-582

### DIFF
--- a/app/importers/californica_csv_cleaner.rb
+++ b/app/importers/californica_csv_cleaner.rb
@@ -38,12 +38,12 @@ class CalifornicaCsvCleaner < Darlingtonia::CsvParser
     CSV.parse(file.read, headers: true).each_with_index do |row, _index|
       item = Darlingtonia::InputRecord.from(metadata: row, mapper: CalifornicaMapper.new)
       ark = item.mapper.metadata["Item Ark"]
-      Work.where(identifier: ark).each { |work| work&.destroy! }
-      Work.where(ark_ssi: ark).each { |work| work&.destroy! }
+      Work.where(identifier: ark).each { |work| work&.destroy&.eradicate }
+      Work.where(ark_ssi: ark).each { |work| work&.destroy&.eradicate }
       ark = Ark.ensure_prefix(ark)
-      Work.where(identifier: ark).each { |work| work&.destroy! }
-      Work.where(ark_ssi: ark).each { |work| work&.destroy! }
-      Work.where(local_identifier: item.mapper.metadata["AltIdentifier.local"]).each { |work| work&.destroy! }
+      Work.where(identifier: ark).each { |work| work&.destroy&.eradicate }
+      Work.where(ark_ssi: ark).each { |work| work&.destroy&.eradicate }
+      Work.where(local_identifier: item.mapper.metadata["AltIdentifier.local"]).each { |work| work&.destroy&.eradicate }
     end
 
     # info_stream << "Actually processed #{actual_records_processed} records"

--- a/spec/importers/californica_csv_cleaner_spec.rb
+++ b/spec/importers/californica_csv_cleaner_spec.rb
@@ -2,22 +2,40 @@
 
 require 'rails_helper'
 
-RSpec.describe CalifornicaCsvCleaner do
+RSpec.describe CalifornicaCsvCleaner, :clean do
   subject(:cleaner) { described_class.new(file: file) }
   let(:file)        { File.open(csv_path) }
   let(:csv_path)    { 'spec/fixtures/example.csv' }
-  let(:work)        { FactoryBot.create(:work, identifier: ["21198/zz0002nq4w"]) }
-  let(:other_work)  { FactoryBot.create(:work, identifier: ["21198/zz0002nq4zzz"]) }
+  let(:record1)     { Darlingtonia::InputRecord.from(metadata: metadata1, mapper: CalifornicaMapper.new) }
+  let(:record2)     { Darlingtonia::InputRecord.from(metadata: metadata2, mapper: CalifornicaMapper.new) }
+  let(:metadata1) do
+    {
+      'Title' => 'Comet in Moominland',
+      'language' => 'English',
+      'visibility' => 'open',
+      'Item Ark' => 'ark:/21198/zz0002nq4w'
+    }
+  end
+  let(:metadata2) do
+    {
+      'Title' => 'World Tales',
+      'language' => 'English',
+      'visibility' => 'open',
+      'Item Ark' => 'ark:/21198/zz0002nq4x'
+    }
+  end
 
   describe 'when we need to reingest', :clean do
     before do
-      work
-      other_work
+      ActorRecordImporter.new.import(record: record1)
+      ActorRecordImporter.new.import(record: record2)
     end
-    it 'removes all objects matching the unique id in a CSV file' do
+    it 'eradicates all objects matching the unique id in a CSV file' do
       expect(Work.count).to eq 2
       cleaner.clean
       expect(Work.count).to eq 1
+      ActorRecordImporter.new.import(record: record1)
+      expect(Work.count).to eq 2
     end
   end
 end


### PR DESCRIPTION
This is necessary so we can re-import works with the same ARK