### PR TITLE
Default to AND operator for search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -31,6 +31,7 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: 'search',
+      mm: '100%',
       rows: 10,
       qf: 'title_tesim description_tesim creator_tesim keyword_tesim'
     }

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Search the catalog', :clean, type: :system, js: true do
       subject: ['fruit'],
       named_subject: ['dessert'],
       location: ['on the table'],
-      description: ['potassium'],
+      description: ['potassium', 'yum'],
       caption: ['tropical'],
       identifier: ['ban_ark'],
       local_identifier: ['12345'],
@@ -30,7 +30,7 @@ RSpec.describe 'Search the catalog', :clean, type: :system, js: true do
       subject: ['veg'],
       named_subject: ['side dish'],
       location: ['in the fridge'],
-      description: ['beta carotene'],
+      description: ['beta carotene', 'yum'],
       caption: ['northern'],
       identifier: ['car_ark'],
       local_identifier: ['67890'],
@@ -88,7 +88,7 @@ RSpec.describe 'Search the catalog', :clean, type: :system, js: true do
     end
 
     # Search by description
-    fill_in 'search-field-header', with: 'potassium'
+    fill_in 'search-field-header', with: 'potassium yum'
     click_on 'search-submit-header'
     within '#search-results' do
       expect(page).to     have_link('Yellow Banana')


### PR DESCRIPTION
This uses the `mm` solr property for the
default search settings in the catalog controller
to make the default search behave like an AND
search with multiple terms.

Connected to CAL-589