### PR TITLE
Remove collection size indexing to speed up ingest CAL-581

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ Metrics/AbcSize:
     - app/jobs/hyrax/characterize_job.rb
     - app/importers/actor_record_importer.rb
     - app/uploaders/csv_manifest_validator.rb
+    - app/importers/collection_record_importer.rb
 
 Metrics/ClassLength:
   Enabled: true
@@ -45,6 +46,7 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - app/uploaders/csv_manifest_validator.rb
     - app/importers/actor_record_importer.rb
+    - app/importers/californica_csv_parser.rb
 
 Metrics/LineLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'xray-rails'
 end
 
 group :development, :test do
@@ -78,4 +77,5 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'simplecov', '~> 0.16.1'
   gem 'solr_wrapper', '>= 0.3'
+  gem 'xray-rails'
 end

--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -22,6 +22,7 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
     self.error_stream = error_stream
     self.info_stream  = info_stream
     @import_file_path = import_file_path
+    @collections_needing_reindex = []
 
     self.validators = [
       Darlingtonia::CsvFormatValidator.new(error_stream: error_stream),
@@ -50,14 +51,33 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
     []
   end
 
+  # Given an array of ARKs:
+  #   1. Remove any blanks
+  #   2. deduplicate the list
+  #   3. find any matching collection objects
+  #   4. reindex any matching collection objects
+  # This is so we can remove expensive collection reindexing behavior during
+  # ingest and only add it back after the ingest is complete.
+  def reindex_collections
+    list = @collections_needing_reindex.reject(&:blank?).uniq
+    list.each do |ark|
+      collection = Collection.find_by_ark(Ark.ensure_prefix(ark))
+      collection.recalculate_size = true
+      collection.save # The save should kick off a reindex
+    end
+  end
+
   def records
     return enum_for(:records) unless block_given?
     file.rewind
-    # use the CalifornicaMapper
     CSV.parse(file.read, headers: true).each_with_index do |row, index|
       next unless index >= skip
       next if row.to_h.values.all?(&:nil?)
+      # use the CalifornicaMapper
       yield Darlingtonia::InputRecord.from(metadata: row, mapper: CalifornicaMapper.new(import_file_path: @import_file_path))
+      # Gather all collection objects that have been touched during this import so we can reindex them all at the end
+      @collections_needing_reindex << row["Item Ark"] if row["Object Type"] == "Collection"
+      @collections_needing_reindex << row["Parent ARK"] if row["Object Type"] == "Work"
     end
   rescue CSV::MalformedCSVError
     # error reporting for this case is handled by validation

--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -29,6 +29,7 @@ class CalifornicaImporter
 
     record_importer = ::RecordImporter.new(error_stream: @error_stream, info_stream: @info_stream, attributes: attrs)
     Darlingtonia::Importer.new(parser: parser, record_importer: record_importer, info_stream: @info_stream, error_stream: @error_stream).import if parser.validate
+    parser.reindex_collections
   end
 
   def parser

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -169,10 +169,17 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     metadata[CALIFORNICA_TERMS_MAP[name]]&.split(DELIMITER)
   end
 
+  def ensure_recalculate_size_is_off(collection)
+    return unless collection.recalculate_size
+    collection.recalculate_size = false
+    collection.save
+  end
+
   def member_of_collections_attributes
     ark = Ark.ensure_prefix(metadata['Parent ARK'])
     return unless ark
     collection = Collection.find_or_create_by_ark(ark)
+    # ensure_recalculate_size_is_off(collection)
     { '0' => { id: collection.id } }
   end
 

--- a/app/importers/collection_record_importer.rb
+++ b/app/importers/collection_record_importer.rb
@@ -12,7 +12,7 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
 
     collection = Collection.find_or_create_by_ark(record.ark)
     collection.attributes = attributes_for(record: record)
-
+    collection.recalculate_size = false
     if collection.save
       info_stream << "event: collection_created, batch_id: #{batch_id}, record_id: #{collection.id}, record_title: #{collection.title}"
       @success_count += 1
@@ -29,7 +29,7 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
 
     collection = existing_record
     collection.attributes = attributes_for(record: update_record)
-
+    collection.recalculate_size = false
     if collection.save
       info_stream << "event: collection_updated, batch_id: #{batch_id}, record_id: #{collection.id}, #{deduplication_field}: #{collection.respond_to?(deduplication_field) ? collection.send(deduplication_field) : collection}"
       @success_count += 1

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,6 +4,11 @@ class Collection < ActiveFedora::Base
   include ::Hyrax::CollectionBehavior
   include UclaMetadata
 
+  # Re-calculating a collection's size is very expensive, and we need a way to turn it off during bulk import
+  property :recalculate_size, predicate: ::RDF::URI.intern('https://library.ucla.edu/bytes_computing_disabled'), multiple: false do |index|
+    index.as :stored_sortable
+  end
+
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   self.indexer = ::CollectionIndexer
@@ -14,6 +19,13 @@ class Collection < ActiveFedora::Base
   # @return [Collection] The Collection with that ARK
   def self.find_by_ark(ark)
     where(ark_ssi: ark).limit(1).first
+  end
+
+  # Do not recalculate size unless recalculate_size == true
+  # Recalculating collection size is expensive, so only do it if we really need it.
+  def bytes
+    return 0 unless recalculate_size
+    super
   end
 
   # @param ark [String] The ARK

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -182,4 +182,12 @@ RSpec.describe Collection do
     expect(collection.services_contact).to include 'UCLA Charles E. Young Research Library Department of Special Collections'
     expect(collection.resource.dump(:ttl)).to match(/www.ebu.ch\/metadata\/ontologies\/ebucore\/ebucore\#hasRightsContact/)
   end
+
+  # Re-calculating a collection's size is very expensive, and we need a way to turn it off during bulk import
+  it 'can disable re-computing of size' do
+    collection.recalculate_size = false
+    expect(collection.recalculate_size).to eq false
+    collection.recalculate_size = true
+    expect(collection.recalculate_size).to eq true
+  end
 end

--- a/spec/system/delete_work_spec.rb
+++ b/spec/system/delete_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Delete a Work', type: :system, js: true do
+RSpec.describe 'Delete a Work', :clean, type: :system, js: true do
   let(:work) { FactoryBot.create(:work, ark: 'ark:/abc/1234') }
   let(:recreated_work) { FactoryBot.create(:work, ark: 'ark:/abc/1234') }
 


### PR DESCRIPTION
* Turn off collection size calculation during ingest
* This sets us up for further work moving all collection re-indexing to the end of the ingest process

Improvement so far (because re-calculating the size of a collection gets more expensive the larger the collection gets, I would expect these numbers to be more dramatically different for LADNN than they are for Bennett):

Before:

I, [2019-05-01T11:40:36.807328 #24190]  INFO -- : event: finish_import, batch_id: 4, successful_record_count: 80, failed_record_count: 0, elapsed_time: 1656.7904343120172, elapsed_time_per_record: 20.709880428900213

After:

I, [2019-05-01T15:35:43.436054 #12308]  INFO -- : event: finish_import, batch_id: 5, successful_record_count: 80, failed_record_count: 0, elapsed_time: 1552.5210038349032, elapsed_time_per_record: 19.40651254793629
