### PR TITLE
Warn users that only /opt/data is valid for file import

### DIFF
--- a/app/views/csv_imports/_form.html.erb
+++ b/app/views/csv_imports/_form.html.erb
@@ -41,7 +41,8 @@
         <div class="col-md-4">
           <div class="well well-lg">
             <p> <b>Type a directory path</b> where your binary attachments can be found.<br/>
-              It should look something like this: <b>/opt/data/Masters/dlmasters/bennett/masters</b>
+              It should look something like this: <b>/opt/data/Masters/dlmasters/bennett/masters</b>.
+              <br/>Note that only directories inside <b>/opt/data</b> will work.
              </p>
             <div class="text-center">
               <%= render "import_file_path", form: form  %>


### PR DESCRIPTION
If a user tries to reference files anywhere other than `/opt/data`, it will not work. This change tells them that up front, to prevent any confusion should someone decide to try something non-standard.  
![opt_data_warning](https://user-images.githubusercontent.com/65608/56971335-0acb9c00-6b37-11e9-9f4a-302b4841b05b.png)
