### PR TITLE
Restore ApplyPermissionTemplateActor

### DIFF
--- a/app/services/californica/ingest_middleware_stack.rb
+++ b/app/services/californica/ingest_middleware_stack.rb
@@ -47,7 +47,7 @@ module Californica
         # middleware.use Hyrax::Actors::TransferRequestActor
 
         # Copies default permissions from the PermissionTemplate to the work
-        # middleware.use Hyrax::Actors::ApplyPermissionTemplateActor
+        middleware.use Hyrax::Actors::ApplyPermissionTemplateActor
 
         # Remove attached FileSets when destroying a work
         # middleware.use Hyrax::Actors::CleanupFileSetsActor


### PR DESCRIPTION
Josh, Andy, Bess, Mark and Lisa all discussed the import actor stack,
documented here:
https://docs.library.ucla.edu/pages/viewpage.action?spaceKey=CUP&title=Californica+CSV+Importer+Notes

We agreed the stripped down version mostly looked fine, except that we
should add the ApplyPermissionTemplateActor back in.