### PR TITLE
Ensure we can delete and re-create works and collections

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -12,6 +12,16 @@ module Hyrax
         Hyrax::CalifornicaCollectionsForm
       end
 
+      # Override #destroy method from Hyrax. Because we are using ark based identifiers, we need to both
+      # destroy and eradicate the object, so that we can re-create a collection object with the same ark if needed
+      def destroy
+        if @collection.destroy.eradicate
+          after_destroy(params[:id])
+        else
+          after_destroy_error(params[:id])
+        end
+      end
+
       # Override #create method from Hyrax to assign an ark based identifier to any newly created collection objects
       def create
         # Manual load and authorize necessary because Cancan will pass in all

--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -11,5 +11,15 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::WorkPresenter
+
+    # Override from Hyrax. Because we are using ark-based identifiers we need to both
+    # destroy and eradicate an object when it is deleted. Otherwise, a tombstone resource
+    # is left in fedora and we cannot re-create an object that has the same ark.
+    def destroy
+      title = curation_concern.to_s
+      return unless curation_concern&.destroy&.eradicate
+      Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
+      after_destroy_response(title)
+    end
   end
 end

--- a/spec/system/delete_work_spec.rb
+++ b/spec/system/delete_work_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Delete a Work', type: :system, js: true do
+  let(:work) { FactoryBot.create(:work, ark: 'ark:/abc/1234') }
+  let(:recreated_work) { FactoryBot.create(:work, ark: 'ark:/abc/1234') }
+
+  let(:admin) { FactoryBot.create(:admin) }
+
+  context "as an admin" do
+    it "can re-create a deleted work with the same ark" do
+      login_as admin
+      visit("/concern/works/#{work.id}")
+      expect(page).to have_content work.title.first
+      expect(page).to have_content work.subject.first
+      expect(page).to have_content work.ark
+
+      # Now delete the work and create it again.
+      visit "/concern/works/#{work.id}"
+      click_on 'Delete'
+      page.driver.browser.switch_to.alert.accept
+      expect(page).to have_content("Deleted #{work.title.first}")
+      expect(Work.count).to eq 0
+
+      visit("/concern/works/#{recreated_work.id}")
+      expect(page).to have_content recreated_work.title.first
+      expect(page).to have_content recreated_work.subject.first
+      expect(page).to have_content work.ark
+    end
+  end
+end

--- a/spec/system/new_collection_spec.rb
+++ b/spec/system/new_collection_spec.rb
@@ -31,6 +31,27 @@ RSpec.describe 'Create a new collection', :clean, type: :system, js: true do
       expect(page).to have_content 'Collection was successfully created.'
       collection = Collection.last
       expect(collection.id).to eq '4321-cba'
+
+      # If you delete the collection, you should be able to re-create it with the same ark
+      visit "/dashboard/collections/#{collection.id}"
+      click_on 'Delete collection'
+      page.driver.browser.switch_to.alert.accept
+      expect(page).to have_content("Collection was successfully deleted")
+      expect(Collection.count).to eq 0
+
+      visit "/dashboard/my/collections"
+      click_on 'New Collection'
+      choose('User Collection')
+      click_on 'Create collection'
+      fill_in('Title', with: title)
+      fill_in('Ark', with: ark)
+      click_on 'Save'
+      expect(page).to have_content title
+      expect(find_field('Ark').value).to eq ark
+      expect(page).to have_content 'Collection was successfully created.'
+      expect(Collection.count).to eq 1
+      collection = Collection.last
+      expect(collection.id).to eq '4321-cba'
     end
   end
 end


### PR DESCRIPTION
Because we're using ark-based identifiers, we have to both destroy and
eradicate a work when it is deleted. Otherwise, it leaves a tombstone
resource behind in fedora and we can't re-create a new object with the
same ark.