### PR TITLE
Update Dockerfile.solr

### DIFF
--- a/docker/Dockerfile.solr
+++ b/docker/Dockerfile.solr
@@ -1,4 +1,4 @@
-FROM solr
+FROM solr:6.5
 
 RUN mkdir /opt/solr/server/solr/mycores/californica
 RUN mkdir /opt/solr/server/solr/mycores/californica/data


### PR DESCRIPTION
This specifies the 6.5 release of solr in the Dockerfile.solr file. The `latest` version isn't working with this Dockerfile yet. 

Connected to CAL-595