### PR TITLE
CAL-581: move collection update index to end of ingest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,7 @@ Metrics/MethodLength:
     - app/forms/hyrax/californica_collections_form.rb
     - 'app/importers/csv_validator.rb'
     - app/uploaders/csv_manifest_validator.rb
+    - app/indexers/collection_indexer.rb
 
 Metrics/PerceivedComplexity:
   Enabled: true

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -182,17 +182,10 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     metadata[CALIFORNICA_TERMS_MAP[name]]&.split(DELIMITER)
   end
 
-  def ensure_recalculate_size_is_off(collection)
-    return unless collection.recalculate_size
-    collection.recalculate_size = false
-    collection.save
-  end
-
   def member_of_collections_attributes
     ark = Ark.ensure_prefix(metadata['Parent ARK'])
     return unless ark
     collection = Collection.find_or_create_by_ark(ark)
-    # ensure_recalculate_size_is_off(collection)
     { '0' => { id: collection.id } }
   end
 

--- a/app/importers/collection_record_importer.rb
+++ b/app/importers/collection_record_importer.rb
@@ -13,7 +13,7 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
     collection = Collection.find_or_create_by_ark(record.ark)
     collection.attributes = attributes_for(record: record)
     collection.recalculate_size = false
-    if collection.save
+    if collection.save(update_index: false)
       info_stream << "event: collection_created, batch_id: #{batch_id}, record_id: #{collection.id}, record_title: #{collection.title}"
       @success_count += 1
     else

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -3,8 +3,28 @@
 # Include any special UCLA Collection indexing here
 class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
   def generate_solr_document
+    return solr_during_indexing unless object.recalculate_size
     super.tap do |solr_doc|
       solr_doc['ursus_id_ssi'] = Californica::IdGenerator.blacklight_id_from_ark(object.ark)
     end
+  end
+
+  # Return a minimal placeholder solr document during ingest
+  def solr_during_indexing
+    {
+      "has_model_ssim" => ["Collection"],
+      :id => object.id,
+      "title_tesim" => ["Ingesting now: #{object.title.first}"],
+      "title_sim" => ["Ingesting now: #{object.title.first}"],
+      "collection_type_gid_ssim" => [object.collection_type_gid],
+      "ark_ssi" => object.ark,
+      "ursus_id_ssi" => Californica::IdGenerator.blacklight_id_from_ark(object.ark),
+      "member_ids_ssim" => [],
+      "object_ids_ssim" => [],
+      "member_of_collection_ids_ssim" => [], "collection_ids_ssim" => [],
+      "generic_type_sim" => ["Collection"],
+      "bytes_lts" => 0,
+      "visibility_ssi" => "restricted"
+    }
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -28,6 +28,17 @@ class Collection < ActiveFedora::Base
     super
   end
 
+  # Do not reindex the collection upon save unless reindex is on explicitly
+  def update_index(*args)
+    super if recalculate_size
+  end
+
+  # Do a "limited" reindex unless recalculate_size is turned on
+  def reindex_extent
+    return "limited" unless recalculate_size
+    Hyrax::Adapters::NestingIndexAdapter::FULL_REINDEX
+  end
+
   # @param ark [String] The ARK
   # @return [Collection] The Collection with that ARK
   def self.find_or_create_by_ark(ark)

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe 'Show a collection', :clean, type: :system, js: true do
     collection_attrs.each do |k, v|
       collection.send((k.to_s + "=").to_sym, v)
     end
+    collection.recalculate_size = true
     collection.save
   end
 


### PR DESCRIPTION
This builds on previous work that disabled collection size re-calculation during ingest. Now, we also turn off collection level solr indexing and collection level nested indexing during ingest, and then re-enable them once ingest is over. 

