### PR TITLE
Rake task to fix collection type labels

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,9 +76,21 @@ namespace :sidekiq do
   end
 end
 
+namespace :californica do
+  task :fix_collection_type_labels do
+    on roles(:app) do
+      execute "cd #{deploy_to}/current; /usr/bin/env bundle exec rake californica:fix_collection_type_labels RAILS_ENV=production"
+    end
+  end
+end
+
 # After the code has been deployed, run db:seed
 # This creates the default admin user
 after 'deploy:published', 'rails:rake:db:seed'
+
+# After the code has been deployed, run californica:fix_collection_type_labels
+# This will fix the translation labels for any collections that are missing them.
+after 'deploy:published', 'californica:fix_collection_type_labels'
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/lib/tasks/fix_collection_type_labels.rake
+++ b/lib/tasks/fix_collection_type_labels.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# Run this if you are seeing Collections with a type of "translation missing..."
+# Check YOUR_SERVER//dashboard/collections?locale=en for a place where this might appear
+namespace :californica do
+  desc "Fix missing collection type labels"
+  task fix_collection_type_labels: :environment do
+    collection_types = Hyrax::CollectionType.all
+    collection_types.each do |c|
+      next unless c.title.match?(/^translation missing/)
+      oldtitle = c.title
+      c.title = I18n.t(c.title.gsub("translation missing: en.", ''))
+      c.save
+      puts "#{oldtitle} changed to #{c.title}"
+    end
+  end
+end


### PR DESCRIPTION
It runs on deploy so it will run on production without needing sysadmin
intervention.

Before:

![collection_translations_before](https://user-images.githubusercontent.com/65608/57254892-71155a80-7020-11e9-884c-217be789270b.png)

After:

![collection_translations_after](https://user-images.githubusercontent.com/65608/57254914-8094a380-7020-11e9-9e28-65d33429a553.png)

During deploy:
![fix_labels_on_deploy](https://user-images.githubusercontent.com/65608/57254922-85f1ee00-7020-11e9-80bf-c9f8522d1349.png)
