### PR TITLE
Use FITS Servlet

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,7 @@ FEDORA_BASE_PATH=/dev
 FEDORA_USER=fedoraAdmin
 FEDORA_PASSWORD=fedoraAdmin
 FEDORA_URL=http://127.0.0.1:8984/rest
+FITS_SERVLET_URL=http://fits:8080/fits
 IMPORT_FILE_PATH=/opt/data
 GEONAMES_USERNAME=
 MISSING_FILE_LOG=log/missing_files.log

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'darlingtonia', '>= 3.2.2'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'dotenv-rails', '~> 2.2.1'
+gem 'hydra-file_characterization', '~> 1.1'
 gem 'hydra-role-management', '~> 1.0.0'
 gem 'hyrax', '2.5.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
       rails (>= 4.2.0, < 6)
       simple_form (~> 3.2)
       sprockets-es6
-    hydra-file_characterization (0.3.3)
+    hydra-file_characterization (1.1.0)
       activesupport (>= 3.0.0)
     hydra-head (10.6.2)
       hydra-access-controls (= 10.6.2)
@@ -356,10 +356,10 @@ GEM
       blacklight
       bootstrap_form
       cancancan
-    hydra-works (1.1.0)
+    hydra-works (1.2.0)
       activesupport (>= 4.2.10, < 6.0)
       hydra-derivatives (~> 3.0)
-      hydra-file_characterization (~> 0.3, >= 0.3.3)
+      hydra-file_characterization (~> 1.0)
       hydra-pcdm (>= 0.9)
     hyrax (2.5.0)
       active-fedora (~> 11.5, >= 11.5.2)
@@ -535,7 +535,7 @@ GEM
     noid-rails (3.0.1)
       actionpack (>= 5.0.0, < 6)
       noid (~> 0.9)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -603,7 +603,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rb-readline (0.5.5)
-    rdf (3.0.10)
+    rdf (3.0.12)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -649,11 +649,11 @@ GEM
       rdf-turtle (~> 3.0, >= 3.0.3)
     rdf-trix (2.2.1)
       rdf (>= 2.2, < 4.0)
-    rdf-turtle (3.0.5)
+    rdf-turtle (3.0.6)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.4)
-      rdf (~> 3.0)
+    rdf-vocab (3.0.6)
+      rdf (~> 3.0, >= 3.0.11)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
     redcarpet (3.4.0)
@@ -871,6 +871,7 @@ DEPENDENCIES
   factory_bot_rails
   fcrepo_wrapper
   ffaker
+  hydra-file_characterization (~> 1.1)
   hydra-role-management (~> 1.0.0)
   hyrax (= 2.5.0)
   jbuilder (~> 2.5)

--- a/app/lib/californica/is_valid_image.rb
+++ b/app/lib/californica/is_valid_image.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Californica
+  class IsValidImage
+    def initialize(image:)
+      @image = image
+    end
+
+    def valid?
+      MiniMagick::Image.new(@image).identify
+      return true
+    rescue MiniMagick::Error
+      return false
+    end
+  end
+end

--- a/config/initializers/characterization_service.rb
+++ b/config/initializers/characterization_service.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+require 'hydra-file_characterization'
+require 'nokogiri'
+
+module Hydra::Works
+  class CharacterizationService
+    # @param [Hydra::PCDM::File] object which has properties to recieve characterization values.
+    # @param [String, File] source for characterization to be run on.  File object or path on disk.
+    #   If none is provided, it will assume the binary content already present on the object.
+    # @param [Hash] options to be passed to characterization.  parser_mapping:, parser_class:, tools:
+    def self.run(object, source = nil, options = {})
+      new(object, source, options).characterize
+    end
+
+    attr_accessor :object, :source, :mapping, :parser_class, :tools
+
+    def initialize(object, source, options)
+      @object       = object
+      @source       = source
+      @mapping      = options.fetch(:parser_mapping, Hydra::Works::Characterization.mapper)
+      @parser_class = options.fetch(:parser_class, Hydra::Works::Characterization::FitsDocument)
+    end
+
+    # Get given source into form that can be passed to Hydra::FileCharacterization
+    # Use Hydra::FileCharacterization to extract metadata (an OM XML document)
+    # Get the terms (and their values) from the extracted metadata
+    # Assign the values of the terms to the properties of the object
+    def characterize
+      content = source_to_content
+      extracted_md = extract_metadata(content)
+      terms = parse_metadata(extracted_md)
+      store_metadata(terms)
+    end
+
+    protected
+
+      # @return content of object if source is nil; otherwise, return a File or the source
+      def source_to_content
+        return object.content if source.nil?
+        # do not read the file into memory It could be huge...
+        return File.open(source) if source.is_a? String
+        source.rewind
+        source.read
+      end
+
+      def extract_metadata(content)
+        if ENV['FITS_SERVLET_URL']
+          Hydra::FileCharacterization.characterize(content, file_name, :fits_servlet)
+        else
+          Hydra::FileCharacterization.characterize(content, file_name, :fits) do |cfg|
+            cfg[:fits] = Hydra::Derivatives.fits_path
+          end
+        end
+      end
+
+      # Determine the filename to send to Hydra::FileCharacterization. If no source is present,
+      # use the name of the file from the object; otherwise, use the supplied source.
+      def file_name
+        if source
+          source.is_a?(File) ? File.basename(source.path) : File.basename(source)
+        else
+          object.original_name.nil? ? "original_file" : object.original_name
+        end
+      end
+
+      # Use OM to parse metadata
+      def parse_metadata(metadata)
+        omdoc = parser_class.new
+        omdoc.ng_xml = Nokogiri::XML(metadata) if metadata.present?
+        omdoc.__cleanup__ if omdoc.respond_to? :__cleanup__
+        characterization_terms(omdoc)
+      end
+
+      # Get proxy terms and values from the parser
+      def characterization_terms(omdoc)
+        h = {}
+        omdoc.class.terminology.terms.each_pair do |key, target|
+          # a key is a proxy if its target responds to proxied_term
+          next unless target.respond_to? :proxied_term
+          begin
+            h[key] = omdoc.send(key)
+          rescue NoMethodError
+            next
+          end
+        end
+        h.delete_if { |_k, v| v.empty? }
+      end
+
+      # Assign values of the instance properties from the metadata mapping :prop => val
+      def store_metadata(terms)
+        terms.each_pair do |term, value|
+          property = property_for(term)
+          next if property.nil?
+          # Array-ify the value to avoid a conditional here
+          Array(value).each { |v| append_property_value(property, v) }
+        end
+      end
+
+      # Check parser_config then self for matching term.
+      # Return property symbol or nil
+      def property_for(term)
+        if mapping.key?(term) && object.respond_to?(mapping[term])
+          mapping[term]
+        elsif object.respond_to?(term)
+          term
+        end
+      end
+
+      def append_property_value(property, value)
+        # We don't want multiple mime_types; this overwrites each time to accept last value
+        value = object.send(property) + [value] unless property == :mime_type
+        # We don't want multiple heights / widths, pick the max
+        value = value.map(&:to_i).max.to_s if property == :height || property == :width
+        object.send("#{property}=", value)
+      end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - solr
       - fedora_test
       - solr_test
+      - fits
     env_file:
       - ./.env.sample
     environment:
@@ -23,6 +24,7 @@ services:
       REDIS_URL: redis://redis:6379/0
       SOLR_URL: http://solr:8983/solr/californica
       SOLR_TEST_URL: http://solr_test:8983/solr/californica
+      FITS_SERVLET_URL: http://fits:8080/fits
     ports:
       - "3000:3000"
     volumes:
@@ -121,6 +123,11 @@ services:
       dockerfile: docker/Dockerfile.solr
     ports:
       - "8985:8983"
+
+  fits:
+    image: harvardlts/fitsservlet_container:latest
+    ports:
+      - "8889:8080"
 
   # iiif:
   #   image: uclalibrary/cantaloupe

--- a/spec/jobs/start_csv_import_job_spec.rb
+++ b/spec/jobs/start_csv_import_job_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe StartCsvImportJob, :clean, :inline_jobs do
       described_class.perform_now(csv_import.id)
       expect(Collection.count).to eq 1
       expect(Work.count).to eq 1
-      expect(Work.last.members.first.files.first.metadata.mime_type.first).not_to match(/tiff/)
       characterization_error = output.string
       expect(characterization_error).to match(/event: unexpected file characterization/)
       expect(characterization_error).to match(/ark: #{Work.last.ark}/)
       expect(characterization_error).to match(/work_id: #{Work.last.id}/)
       expect(characterization_error).to match(/food.tif/)
-      expect(characterization_error).to match(/mime_type: application\/octet-stream/)
+      # Different versions of FITS return different mime types
+      expect(characterization_error).to match(/mime_type: image\/tiff/).or match(/mime_type: application\/octet-stream/)
     end
   end
 end

--- a/spec/lib/californica/is_valid_image_spec.rb
+++ b/spec/lib/californica/is_valid_image_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Californica::IsValidImage do
+  let(:corrupted_file) { Rails.root.join('spec', 'fixtures', 'images', 'corrupted', 'food.tif') }
+  let(:good_file) { Rails.root.join('spec', 'fixtures', 'images', 'good', 'food.tif') }
+  let(:is_valid_image_with_corrupted_file) { described_class.new(image: corrupted_file) }
+  let(:is_valid_image) { described_class.new(image: good_file) }
+
+  describe '#valid?' do
+    it 'returns false if the image is currupted' do
+      expect(is_valid_image_with_corrupted_file.valid?).to eq(false)
+    end
+
+    it 'returns true if the image is valid' do
+      expect(is_valid_image.valid?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This commit allows you to use an external
FITS Servlet for file characterization. To turn
it on, set the 'FITS_SERVLET_URL' environment varible
on your server before starting the server. This is
accomplished with overrides and prepends, so it won't
be possible for a FlipFlop feature to toggle this, because
you will need to restart your server.

The FITS servlet URL should be the full path to the FITS endpoint.

In the `docker-compose` environment this is at `http://fits:8080/fits` and the 
specs are run using the external fits servlet. On travis, the default FITS 
behavior (using the local version) is used. 

If the `FITS_SERVLET_URL` is not set, the server will use the default
FITS installation.



Connected to CAL-580