### PR TITLE
rights statements

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -170,10 +170,13 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   # not a valid value, it will eventually be rejected
   # by the RightsStatementValidator.
   def rights_statement
-    return unless metadata['Rights.copyrightStatus']
-    rights_term = Qa::Authorities::Local.subauthority_for('rights_statements').all.find { |h| h[:label] == metadata['Rights.copyrightStatus'] }
-    rights_value = rights_term.blank? ? metadata['Rights.copyrightStatus'] : rights_term[:id]
-    Array(rights_value)
+    authority = Qa::Authorities::Local.subauthority_for('rights_statements')
+    rights_statement = map_field(:rights_statement).to_a.map do |label|
+      term = authority.all.find { |h| h[:label] == label }
+      term.blank? ? label : term[:id]
+    end
+    rights_statement << authority.all.find { |h| h[:label] == 'unknown' }[:id] if rights_statement.empty?
+    rights_statement
   end
 
   def map_field(name)

--- a/app/uploaders/csv_manifest_validator.rb
+++ b/app/uploaders/csv_manifest_validator.rb
@@ -146,9 +146,14 @@ private
 
       # Row missing reqired field values
       column_numbers.each_with_index do |column_number, j|
-        next unless REQUIRED_VALUES[j][1].include?(object_type)
+        field_label, types_that_require = REQUIRED_VALUES[j]
+        next unless types_that_require.include?(object_type)
         next unless row[column_number].blank?
-        @warnings << "Can't import Row #{i + 1}: missing \"#{REQUIRED_VALUES[j][0]}\"."
+        @warnings << if field_label == 'Rights.copyrightStatus'
+                       "Row #{i + 1}: missing 'Rights.copyrightStatus' will be set to 'unknown'."
+                     else
+                       "Can't import Row #{i + 1}: missing \"#{REQUIRED_VALUES[j][0]}\"."
+                     end
       end
     end
   end

--- a/config/authorities/rights_statements.yml
+++ b/config/authorities/rights_statements.yml
@@ -7,3 +7,6 @@ terms:
 - id: http://vocabs.library.ucla.edu/rights/unknown
   term: "unknown"
   active: true
+- id: http://vocabs.library.ucla.edu/rights/publicDomain
+  term: "public domain"
+  active: true

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -221,19 +221,22 @@ RSpec.describe CalifornicaMapper do
         # No value for "Rights.copyrightStatus"
         let(:metadata) { { 'Title' => 'A title' } }
 
-        it 'returns nil' do
-          expect(mapper.rights_statement).to eq nil
+        it 'returns \'unknown\'' do
+          expect(mapper.rights_statement).to eq ["http://vocabs.library.ucla.edu/rights/unknown"]
         end
       end
 
-      context 'with a valid value' do
+      context 'with valid values' do
         let(:metadata) do
           { 'Title' => 'A title',
-            'Rights.copyrightStatus' => 'copyrighted' }
+            'Rights.copyrightStatus' => 'copyrighted|~|unknown' }
         end
 
         it 'finds the correct ID for the given value' do
-          expect(mapper.rights_statement).to eq ["http://vocabs.library.ucla.edu/rights/copyrighted"]
+          expect(mapper.rights_statement).to contain_exactly(
+            "http://vocabs.library.ucla.edu/rights/copyrighted",
+            "http://vocabs.library.ucla.edu/rights/unknown"
+          )
         end
       end
 

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -229,12 +229,13 @@ RSpec.describe CalifornicaMapper do
       context 'with valid values' do
         let(:metadata) do
           { 'Title' => 'A title',
-            'Rights.copyrightStatus' => 'copyrighted|~|unknown' }
+            'Rights.copyrightStatus' => ['copyrighted', 'unknown', 'public domain'].join('|~|') }
         end
 
         it 'finds the correct ID for the given value' do
           expect(mapper.rights_statement).to contain_exactly(
             "http://vocabs.library.ucla.edu/rights/copyrighted",
+            "http://vocabs.library.ucla.edu/rights/publicDomain",
             "http://vocabs.library.ucla.edu/rights/unknown"
           )
         end

--- a/spec/uploaders/csv_manifest_validator_spec.rb
+++ b/spec/uploaders/csv_manifest_validator_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe CsvManifestValidator, type: :model do
         'Can\'t import Row 4: missing "Title".',
         'Can\'t import Row 5: missing "Object Type".',
         'Can\'t import Row 6: missing "Parent ARK".',
-        'Can\'t import Row 7: missing "Rights.copyrightStatus".',
+        'Row 7: missing \'Rights.copyrightStatus\' will be set to \'unknown\'.',
         'Can\'t import Row 8: missing "File Name".'
       )
     end


### PR DESCRIPTION
- maps missing rights statements values to 'unknown' on ingest (CAL-613)
- adds 'public domain' to rights_statements.yml (CAL-617 – out of sprint but trivial to add)