### PR TITLE
Create ChildWork object type

### DIFF
--- a/app/actors/hyrax/actors/child_work_actor.rb
+++ b/app/actors/hyrax/actors/child_work_actor.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate hyrax:work ChildWork`
+module Hyrax
+  module Actors
+    class ChildWorkActor < WorkActor
+    end
+  end
+end

--- a/app/controllers/hyrax/child_works_controller.rb
+++ b/app/controllers/hyrax/child_works_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate hyrax:work ChildWork`
+module Hyrax
+  # Generated controller for ChildWork
+  class ChildWorksController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::ChildWork
+
+    # Use this line if you want to use a custom presenter
+    self.show_presenter = Hyrax::WorkPresenter
+
+    # Override from Hyrax. Because we are using ark-based identifiers we need to both
+    # destroy and eradicate an object when it is deleted. Otherwise, a tombstone resource
+    # is left in fedora and we cannot re-create an object that has the same ark.
+    def destroy
+      title = curation_concern.to_s
+      return unless curation_concern&.destroy&.eradicate
+      Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
+      after_destroy_response(title)
+    end
+  end
+end

--- a/app/forms/hyrax/child_work_form.rb
+++ b/app/forms/hyrax/child_work_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate hyrax:work ChildWork`
+module Hyrax
+  # Generated form for ChildWork
+  class ChildWorkForm < Hyrax::WorkForm
+    self.model_class = ::ChildWork
+  end
+end

--- a/app/importers/actor_record_importer.rb
+++ b/app/importers/actor_record_importer.rb
@@ -18,6 +18,11 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
     super(error_stream: error_stream, info_stream: info_stream, attributes: attributes)
   end
 
+  def import_type(object_type = nil)
+    return ::ChildWork if object_type == 'Page'
+    ::Work
+  end
+
   # Create an object using the Hyrax actor stack
   # We assume the object was created as expected if the actor stack returns true.
   def create_for(record:)
@@ -29,7 +34,8 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
       batch_id: batch_id
     }
 
-    created = import_type.new
+    object_type = record.mapper.metadata["Object Type"]
+    created = import_type(object_type).new
 
     attrs = record.attributes.merge(additional_attrs)
 

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -54,7 +54,11 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   end
 
   def fields
-    CALIFORNICA_TERMS_MAP.keys + [:remote_files, :visibility, :member_of_collections_attributes, :license]
+    # The fields common to all object types
+    common_fields = CALIFORNICA_TERMS_MAP.keys + [:remote_files, :visibility, :member_of_collections_attributes, :license]
+    # Pages additionally have a field :in_works_ids, which defines their parent work
+    return common_fields + [:in_works_ids] if metadata["Object Type"] == "Page"
+    common_fields
   end
 
   def object_type
@@ -201,6 +205,13 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     return unless ark
     collection = Collection.find_or_create_by_ark(ark)
     { '0' => { id: collection.id } }
+  end
+
+  def in_works_ids
+    return unless metadata["Object Type"] == "Page"
+    ark = Ark.ensure_prefix(metadata['Parent ARK'])
+    parent_work = Work.find_or_create_by_ark(ark)
+    [parent_work.id]
   end
 
   private

--- a/app/models/child_work.rb
+++ b/app/models/child_work.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class ChildWork < ActiveFedora::Base
+  include ::Hyrax::WorkBehavior
+  include UclaMetadata
+
+  self.indexer = WorkIndexer
+  # Change this to restrict which works can be added as a child.
+  # self.valid_child_concerns = []
+  validates :title, presence: { message: 'Your work must have a title.' }
+  validates :ark, presence: { message: 'Your Work must have an ARK.' }
+
+  # This must be included at the end, because it finalizes the metadata
+  # schema (by adding accepts_nested_attributes)
+  include ::Hyrax::BasicMetadata
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -13,4 +13,25 @@ class Work < ActiveFedora::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  # @param ark [String] The ARK
+  # @return [Work] The Work with that ARK
+  def self.find_by_ark(ark)
+    where(ark_ssi: ark).limit(1).first
+  end
+
+  # @param ark [String] The ARK
+  # @return [Work] The Work with that ARK
+  def self.find_or_create_by_ark(ark)
+    work = find_by_ark(ark)
+    return work if work
+
+    work = Work.create(
+      id: Californica::IdGenerator.id_from_ark(ark),
+      title: ["Work #{ark}"],
+      ark: ark,
+      visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    )
+    work
+  end
 end

--- a/app/views/hyrax/child_works/_child_work.html.erb
+++ b/app/views/hyrax/child_works/_child_work.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: child_work, document_counter: child_work_counter  %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -2,6 +2,8 @@
 Hyrax.config do |config|
   # Injected via `rails g hyrax:work Work`
   config.register_curation_concern :work
+  # Injected via `rails g hyrax:work ChildWork`
+  config.register_curation_concern :child_work
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/config/locales/child_work.de.yml
+++ b/config/locales/child_work.de.yml
@@ -1,0 +1,8 @@
+de:
+  hyrax:
+    icons:
+      child_work:     'fa fa-file-text-o'
+    select_type:
+      child_work:
+        description:        "Child work Werke"
+        name:               "Child Work"

--- a/config/locales/child_work.en.yml
+++ b/config/locales/child_work.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      child_work:     'fa fa-file-text-o'
+    select_type:
+      child_work:
+        description:        "Page"
+        name:               "Child Work"

--- a/config/locales/child_work.es.yml
+++ b/config/locales/child_work.es.yml
@@ -1,0 +1,10 @@
+es:
+  hyrax:
+    icons:
+      child_work:     'fa fa-file-text-o'
+    select_type:
+      child_work:
+        # TODO: translate `human_name` into Spanish
+        description:        "Child work trabajos"
+        name:               "Child Work"
+        # TODO: translate `human_name` into Spanish

--- a/config/locales/child_work.fr.yml
+++ b/config/locales/child_work.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  hyrax:
+    icons:
+      child_work:     'fa fa-file-text-o'
+    select_type:
+      child_work:
+        description:        "Child work œuvres"
+        name:               "Child Work"

--- a/config/locales/child_work.it.yml
+++ b/config/locales/child_work.it.yml
@@ -1,0 +1,8 @@
+it:
+  hyrax:
+    icons:
+      child_work:     'fa fa-file-text-o'
+    select_type:
+      child_work:
+        description:        "Child work opere"
+        name:               "Child Work"

--- a/config/locales/child_work.pt-BR.yml
+++ b/config/locales/child_work.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  hyrax:
+    icons:
+      child_work:     'fa fa-file-text-o'
+    select_type:
+      child_work:
+        description:        "Child work trabalhos"
+        name:               "Child Work"

--- a/config/locales/child_work.zh.yml
+++ b/config/locales/child_work.zh.yml
@@ -1,0 +1,10 @@
+zh:
+  hyrax:
+    icons:
+      child_work:     'fa fa-file-text-o'
+    select_type:
+      child_work:
+        # TODO: translate `human_name` into Chinese
+        description:        "Child work 作品"
+        name:               "Child Work"
+        # TODO: translate `human_name` into Chinese

--- a/spec/factories/child_works.rb
+++ b/spec/factories/child_works.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# See https://github.com/ffaker/ffaker for more fake data
+FactoryBot.define do
+  factory :child_work do
+    id { Noid::Rails::Service.new.mint }
+    ark { "ark:/13030/#{Noid::Rails::Service.new.mint}" }
+    title { [] << FFaker::Book.title }
+    subject { [] << FFaker::Education.major }
+    description { [] << FFaker::Lorem.paragraph }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+  end
+end

--- a/spec/forms/hyrax/child_work_form_spec.rb
+++ b/spec/forms/hyrax/child_work_form_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate hyrax:work ChildWork`
+require 'rails_helper'
+
+RSpec.describe Hyrax::ChildWorkForm do
+  let(:form) { described_class.new(Work.new, {}, {}) }
+
+  it 'has all the custom terms' do
+    expect(form.terms).to include(:extent, :architect, :caption, :dimensions,
+                                  :funding_note, :genre, :latitude,
+                                  :longitude, :local_identifier, :medium,
+                                  :named_subject, :normalized_date, :repository,
+                                  :rights_country, :rights_holder, :photographer)
+  end
+end

--- a/spec/importers/collection_record_importer_spec.rb
+++ b/spec/importers/collection_record_importer_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe CollectionRecordImporter, :clean do
     { 'Title' => 'Collection ABC 123',
       'Item Ark' => 'ark:/abc/123',
       'Description.note' => 'desc 1|~|desc 2',
-      'Rights.servicesContact' => 'UCLA Charles E. Young Research Library Department of Special Collections' }
+      'Rights.servicesContact' => 'UCLA Charles E. Young Research Library Department of Special Collections',
+      'Object Type' => 'Collection' }
   end
 
   describe '#import' do
@@ -42,7 +43,8 @@ RSpec.describe CollectionRecordImporter, :clean do
     context 'when the collection creation fails' do
       let(:metadata) do
         { 'Title' => nil, # Nil title is invalid
-          'Item Ark' => 'ark:/abc/123' }
+          'Item Ark' => 'ark:/abc/123',
+          'Object Type' => 'Collection' }
       end
 
       it 'logs the failure' do
@@ -95,7 +97,8 @@ RSpec.describe CollectionRecordImporter, :clean do
 
       let(:metadata) do
         { 'Title' => nil, # Nil title is invalid
-          'Item Ark' => 'ark:/abc/123' }
+          'Item Ark' => 'ark:/abc/123',
+          'Object Type' => 'Collection' }
       end
 
       it 'logs the failure' do

--- a/spec/jobs/mss_csv_import_job_spec.rb
+++ b/spec/jobs/mss_csv_import_job_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe StartCsvImportJob, :clean, :inline_jobs do
       expect(Collection.count).to eq 1
       # For the moment, there are 4 works.
       # Next, we'll turn this into three pages, each attached to a work
-      expect(Work.count).to eq 4
+      expect(Work.count).to eq 1
+      expect(ChildWork.count).to eq 3
       collection = Collection.last
       # The work is attached to the Collection as expected
       expect(collection.child_works.count).to eq 1

--- a/spec/jobs/mss_csv_import_job_spec.rb
+++ b/spec/jobs/mss_csv_import_job_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe StartCsvImportJob, :clean, :inline_jobs do
       # The work is attached to the Collection as expected
       expect(collection.child_works.count).to eq 1
       expect(collection.child_works.first.title.first).to eq "Ms. 50 Marbabeta Salomon, Ṣalota Susnyos"
+      # The Pages are attached to the Work as expected
+      work = Work.last
+      expect(work.members.size).to eq 3
     end
+  end
+
+  context 'the pages are defined before the work' do
+    pending
   end
 end

--- a/spec/models/child_work_spec.rb
+++ b/spec/models/child_work_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+# Generated via
+#  `rails generate hyrax:work ChildWork`
 require 'rails_helper'
 
-RSpec.describe Work do
+RSpec.describe ChildWork do
   subject(:work) { described_class.new }
   it_behaves_like 'a work with UCLA metadata'
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 RSpec.describe Collection do
   subject(:collection) { described_class.new }
 
+  context 'it has UCLA metadata' do
+    subject(:work) { described_class.new }
+    it_behaves_like 'a work with UCLA metadata'
+  end
+
   describe 'with ARK' do
     let(:ark) { "ark:/coll/222" }
     let(:similar_ark) { 'ark:/coll/222111' }
@@ -63,130 +68,6 @@ RSpec.describe Collection do
         end
       end
     end
-  end
-
-  describe '#genre' do
-    let(:values) { ['SciFi'] }
-
-    it 'can set a genre' do
-      expect { collection.genre = values }
-        .to change { collection.genre.to_a }
-        .to contain_exactly(*values)
-    end
-
-    it 'sets to edm:hasType' do
-      expect { collection.genre = values }
-        .to change { collection.resource.predicates }
-        .to include RDF::Vocab::EDM.hasType
-    end
-  end
-
-  it "has architect" do
-    collection.architect = ['architect']
-    expect(collection.architect).to include 'architect'
-    expect(collection.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/relators\/arc/)
-  end
-
-  it "has publisher" do
-    collection.publisher = ['publisher']
-    expect(collection.publisher).to include 'publisher'
-    expect(collection.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/publisher/)
-  end
-
-  it "has extent" do
-    collection.extent = ['1 photograph']
-    expect(collection.extent).to include '1 photograph'
-    expect(collection.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/format/)
-  end
-
-  it "has repository" do
-    collection.repository = ['a repository']
-    expect(collection.repository).to include 'a repository'
-    expect(collection.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#locationCopySublocation/)
-  end
-
-  it "has normalized date" do
-    collection.normalized_date = ['01/01/01']
-    expect(collection.normalized_date).to include '01/01/01'
-    expect(collection.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/date/)
-  end
-
-  it "has local_identifier" do
-    collection.local_identifier = ['local_identifier']
-    expect(collection.local_identifier).to include 'local_identifier'
-    expect(collection.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/identifiers\/local/)
-  end
-
-  it "has funding_note" do
-    collection.funding_note = ['funding_note']
-    expect(collection.funding_note).to include 'funding_note'
-    expect(collection.resource.dump(:ttl)).to match(/bibfra.me\/vocab\/marc\/fundingInformation/)
-  end
-
-  it "has latitude" do
-    collection.latitude = ['39']
-    expect(collection.latitude).to include '39'
-    expect(collection.resource.dump(:ttl)).to match(/w3.org\/2003\/12\/exif\/ns#gpsLatitude/)
-  end
-
-  it "has longitude" do
-    collection.longitude = ['-94']
-    expect(collection.longitude).to include '-94'
-    expect(collection.resource.dump(:ttl)).to match(/w3.org\/2003\/12\/exif\/ns#gpsLongitude/)
-  end
-
-  it "has named subject" do
-    collection.named_subject = ['Person, A']
-    expect(collection.named_subject).to include 'Person, A'
-    expect(collection.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#subjectName/)
-  end
-
-  it "rights country" do
-    collection.rights_country = ['rights_country']
-    expect(collection.rights_country).to include 'rights_country'
-    expect(collection.resource.dump(:ttl)).to match(/ebu.ch\/metadata\/ontologies\/ebucore\/ebucore#rightsType/)
-  end
-
-  it "has rights holder" do
-    collection.rights_holder = ['rights_holder']
-    expect(collection.rights_holder).to include 'rights_holder'
-    expect(collection.resource.dump(:ttl)).to match(/ebu.ch\/metadata\/ontologies\/ebucore\/ebucore#hasRightsHolder/)
-  end
-
-  it "has medium" do
-    collection.medium = ['Capacitance Electronic Disc']
-    expect(collection.medium).to include 'Capacitance Electronic Disc'
-    expect(collection.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/medium/)
-  end
-
-  it "has dimensions" do
-    collection.dimensions = ['2x4']
-    expect(collection.dimensions).to include '2x4'
-    expect(collection.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#physicalExtent/)
-  end
-
-  it "has caption" do
-    collection.caption = ['a caption']
-    expect(collection.caption).to include 'a caption'
-    expect(collection.resource.dump(:ttl)).to match(/schema.org\/caption/)
-  end
-
-  it "has location" do
-    collection.location = ['a location']
-    expect(collection.location).to include 'a location'
-    expect(collection.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/coverage/)
-  end
-
-  it "has photographer" do
-    collection.photographer = ['Ansel Adams']
-    expect(collection.photographer).to include 'Ansel Adams'
-    expect(collection.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/relators\/pht.html/)
-  end
-
-  it "has services_contact" do
-    collection.services_contact = ['UCLA Charles E. Young Research Library Department of Special Collections']
-    expect(collection.services_contact).to include 'UCLA Charles E. Young Research Library Department of Special Collections'
-    expect(collection.resource.dump(:ttl)).to match(/www.ebu.ch\/metadata\/ontologies\/ebucore\/ebucore\#hasRightsContact/)
   end
 
   # Re-calculating a collection's size is very expensive, and we need a way to turn it off during bulk import

--- a/spec/support/shared_examples/ucla_metadata.rb
+++ b/spec/support/shared_examples/ucla_metadata.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'a work with UCLA metadata' do
+  context 'UCLA metadata attributes' do
+    describe '#genre' do
+      let(:values) { ['SciFi'] }
+
+      it 'can set a genre' do
+        expect { work.genre = values }
+          .to change { work.genre.to_a }
+          .to contain_exactly(*values)
+      end
+
+      it 'sets to edm:hasType' do
+        expect { work.genre = values }
+          .to change { work.resource.predicates }
+          .to include RDF::Vocab::EDM.hasType
+      end
+    end
+
+    it "has a single-valued ark" do
+      work.ark = 'ark:/abc/123456'
+      expect(work.ark).to eq 'ark:/abc/123456'
+      expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/identifier/)
+    end
+
+    it "has architect" do
+      work.architect = ['Imhotep']
+      expect(work.architect).to include 'Imhotep'
+      expect(work.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/relators\/arc/)
+    end
+
+    it "has publisher" do
+      work.publisher = ['publisher']
+      expect(work.publisher).to include 'publisher'
+      expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/publisher/)
+    end
+
+    it "has extent" do
+      work.extent = ['1 photograph']
+      expect(work.extent).to include '1 photograph'
+      expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/format/)
+    end
+
+    it "has repository" do
+      work.repository = ['a repository']
+      expect(work.repository).to include 'a repository'
+      expect(work.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#locationCopySublocation/)
+    end
+
+    it "has normalized date" do
+      work.normalized_date = ['01/01/01']
+      expect(work.normalized_date).to include '01/01/01'
+      expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/elements\/1.1\/date/)
+    end
+
+    it "has local_identifier" do
+      work.local_identifier = ['local_identifier']
+      expect(work.local_identifier).to include 'local_identifier'
+      expect(work.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/identifiers\/local/)
+    end
+
+    it "has funding_note" do
+      work.funding_note = ['funding_note']
+      expect(work.funding_note).to include 'funding_note'
+      expect(work.resource.dump(:ttl)).to match(/bibfra.me\/vocab\/marc\/fundingInformation/)
+    end
+
+    it "has latitude" do
+      work.latitude = ['39']
+      expect(work.latitude).to include '39'
+      expect(work.resource.dump(:ttl)).to match(/w3.org\/2003\/12\/exif\/ns#gpsLatitude/)
+    end
+
+    it "has longitude" do
+      work.longitude = ['-94']
+      expect(work.longitude).to include '-94'
+      expect(work.resource.dump(:ttl)).to match(/w3.org\/2003\/12\/exif\/ns#gpsLongitude/)
+    end
+
+    it "has named subject" do
+      work.named_subject = ['Person, A']
+      expect(work.named_subject).to include 'Person, A'
+      expect(work.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#subjectName/)
+    end
+
+    it "has rights country" do
+      work.rights_country = ['rights_country']
+      expect(work.rights_country).to include 'rights_country'
+      expect(work.resource.dump(:ttl)).to match(/ebu.ch\/metadata\/ontologies\/ebucore\/ebucore#rightsType/)
+    end
+
+    it "has rights holder" do
+      work.rights_holder = ['rights_holder']
+      expect(work.rights_holder).to include 'rights_holder'
+      expect(work.resource.dump(:ttl)).to match(/ebu.ch\/metadata\/ontologies\/ebucore\/ebucore#hasRightsHolder/)
+    end
+
+    it "has medium" do
+      work.medium = ['Capacitance Electronic Disc']
+      expect(work.medium).to include 'Capacitance Electronic Disc'
+      expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/medium/)
+    end
+
+    it "has dimensions" do
+      work.dimensions = ['2x4']
+      expect(work.dimensions).to include '2x4'
+      expect(work.resource.dump(:ttl)).to match(/loc.gov\/mods\/rdf\/v1#physicalExtent/)
+    end
+
+    it "has caption" do
+      work.caption = ['a caption']
+      expect(work.caption).to include 'a caption'
+      expect(work.resource.dump(:ttl)).to match(/schema.org\/caption/)
+    end
+
+    it "has location" do
+      work.location = ['a location']
+      expect(work.location).to include 'a location'
+      expect(work.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/coverage/)
+    end
+
+    it "has photographer" do
+      work.photographer = ['Ansel Adams']
+      expect(work.photographer).to include 'Ansel Adams'
+      expect(work.resource.dump(:ttl)).to match(/id.loc.gov\/vocabulary\/relators\/pht.html/)
+    end
+
+    it "has a collection name" do
+      work.dlcs_collection_name = ["Connell (Will) Papers, 1928-1961"]
+      expect(work.dlcs_collection_name).to include "Connell (Will) Papers, 1928-1961"
+      expect(work.resource.dump(:ttl)).to match(/bib.schema.org\/Collection/)
+    end
+
+    it "has services_contact" do
+      work.services_contact = ['UCLA Charles E. Young Research Library Department of Special Collections']
+      expect(work.services_contact).to include 'UCLA Charles E. Young Research Library Department of Special Collections'
+      expect(work.resource.dump(:ttl)).to match(/www.ebu.ch\/metadata\/ontologies\/ebucore\/ebucore\#hasRightsContact/)
+    end
+  end
+end

--- a/spec/system/create_child_work_spec.rb
+++ b/spec/system/create_child_work_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.describe 'Create a Work', :clean, type: :system, js: true do
+RSpec.describe 'Create a ChildWork', :clean, type: :system, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -27,10 +27,9 @@ RSpec.describe 'Create a Work', :clean, type: :system, js: true do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
-      choose "payload_concern", option: "Work"
+      choose "payload_concern", option: "ChildWork"
       click_button "Create work"
-
-      expect(page).to have_content "Add New Work"
+      expect(page).to have_content "Add New Child Work"
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"
@@ -40,23 +39,23 @@ RSpec.describe 'Create a Work', :clean, type: :system, js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Ark', with: 'ark:/abc/123')
+      fill_in('Ark', with: 'ark:/abc/1236')
       select('copyrighted', from: 'Copyright Status')
 
       # With selenium and the chrome driver, focus remains on the
       # select box. Click outside the box so the next line can't find
       # its element
       find('body').click
-      choose('work_visibility_open')
+      choose('child_work_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       click_on('Save')
       expect(page).to have_content('My Test Work')
-      expect(page).to have_content("ark:/abc/123")
+      expect(page).to have_content("ark:/abc/1236")
       expect(page).to have_content("Your files are being processed")
-      work = Work.last
-      expect(work.id).to eq '321-cba'
+      work = ChildWork.last
+      expect(work.id).to eq '6321-cba'
     end
   end
 end

--- a/spec/system/delete_child_work_spec.rb
+++ b/spec/system/delete_child_work_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Delete a ChildWork', :clean, type: :system, js: true do
+  let(:child_work) { FactoryBot.create(:child_work, ark: 'ark:/abc/1234') }
+  let(:recreated_child_work) { FactoryBot.create(:child_work, ark: 'ark:/abc/1234') }
+
+  let(:admin) { FactoryBot.create(:admin) }
+
+  context "as an admin" do
+    it "can re-create a deleted work with the same ark" do
+      login_as admin
+      visit("/concern/works/#{child_work.id}")
+      expect(page).to have_content child_work.title.first
+      expect(page).to have_content child_work.subject.first
+      expect(page).to have_content child_work.ark
+
+      # Now delete the work and create it again.
+      visit "/concern/works/#{child_work.id}"
+      click_on 'Delete'
+      page.driver.browser.switch_to.alert.accept
+      expect(page).to have_content("Deleted #{child_work.title.first}")
+      expect(ChildWork.count).to eq 0
+
+      visit("/concern/works/#{recreated_child_work.id}")
+      expect(page).to have_content recreated_child_work.title.first
+      expect(page).to have_content recreated_child_work.subject.first
+      expect(page).to have_content child_work.ark
+    end
+  end
+end


### PR DESCRIPTION
* It has the same metadata attributes as a Work
* Refactor to share metadata examples
* It subclasses Work where ever possible
* It has an additional field, `in_works_ids`, containing its parent Work object