### PR TITLE
Record page sequence in a PageOrder object

### DIFF
--- a/app/assets/markdown/importer_guide.md
+++ b/app/assets/markdown/importer_guide.md
@@ -19,6 +19,7 @@
 * [Format.dimensions](#format.dimensions)
 * [Format.extent](#format.extent)
 * [Format.medium](#format.medium)
+* [Item Sequence](#item-sequence)
 * [Language](#language)
 * [Name.architect](#name.architect)
 * [Name.photographer](#name.photographer)
@@ -117,6 +118,7 @@ Examples:
 ### Format.dimensions
 ### Format.extent
 ### Format.medium
+### Item Sequence
 ### Language
 ### Name.architect
 ### Name.photographer

--- a/app/models/page_order.rb
+++ b/app/models/page_order.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class PageOrder < ApplicationRecord
+end

--- a/app/uploaders/csv_manifest_validator.rb
+++ b/app/uploaders/csv_manifest_validator.rb
@@ -44,6 +44,7 @@ OPTIONAL_HEADERS = [
   'Format.dimensions',
   'Format.extent',
   'Format.medium',
+  'Item Sequence',
   'Language',
   'Name.architect',
   'Name.photographer',

--- a/db/migrate/20190514132636_create_page_orders.rb
+++ b/db/migrate/20190514132636_create_page_orders.rb
@@ -1,0 +1,11 @@
+class CreatePageOrders < ActiveRecord::Migration[5.1]
+  def change
+    create_table :page_orders do |t|
+      t.string :parent
+      t.string :child
+      t.integer :sequence
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190410165638) do
+ActiveRecord::Schema.define(version: 20190514132636) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -229,6 +229,14 @@ ActiveRecord::Schema.define(version: 20190410165638) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
+  end
+
+  create_table "page_orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "parent"
+    t.string "child"
+    t.integer "sequence"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/jobs/mss_csv_import_job_spec.rb
+++ b/spec/jobs/mss_csv_import_job_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe StartCsvImportJob, :clean, :inline_jobs do
       # The Pages are attached to the Work as expected
       work = Work.last
       expect(work.members.size).to eq 3
+      # It makes a PageOrder object for each Page
+      expect(PageOrder.count).to eq 3
     end
   end
 

--- a/spec/models/page_order_spec.rb
+++ b/spec/models/page_order_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe PageOrder, type: :model do
+  subject(:page_order) { described_class.new }
+
+  it 'can be instantiated' do
+    expect(page_order).to be_instance_of(described_class)
+  end
+end


### PR DESCRIPTION
During import, record a page's sequence in a PageOrder object. This will
make the page order for a given manuscript easy to recalcuate. Once a
manuscript import is complete, we'll query for all that mss's PageOrder
objects, sort them by sequence, and use that to set the order of the
pages.