### PR TITLE
remove all validators from CalifornicaCsvParser

### DIFF
--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -26,11 +26,7 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
     # An array of work ids with attached ChildWorks, which might need a reordering of the attached ChildWorks
     @works_needing_ordering = Set.new
 
-    self.validators = [
-      Darlingtonia::CsvFormatValidator.new(error_stream: error_stream),
-      CsvValidator.new(error_stream: error_stream),
-      Darlingtonia::TitleValidator.new(error_stream: error_stream)
-    ]
+    self.validators = []
 
     super
   end

--- a/spec/importers/californica_csv_parser_spec.rb
+++ b/spec/importers/californica_csv_parser_spec.rb
@@ -84,28 +84,4 @@ RSpec.describe CalifornicaCsvParser do
       end
     end
   end
-
-  describe '#validate' do
-    it 'is valid' do
-      expect(parser.validate).to be_truthy
-    end
-
-    context 'with an invalid csv' do
-      let(:file) { File.open('spec/fixtures/mods_example.xml') }
-
-      it 'is invalid' do
-        expect(parser.validate).to be_falsey
-      end
-    end
-  end
-
-  describe 'validators' do
-    subject(:parser) { described_class.new(file: file, error_stream: error_stream) }
-
-    let(:error_stream) { CalifornicaLogStream.new }
-
-    it 'use the same error stream as the parser' do
-      expect(parser.validators.map(&:error_stream)).to eq [error_stream, error_stream, error_stream]
-    end
-  end
 end


### PR DESCRIPTION
Validation at this level largely duplicates validation done in
CsvManifestValidator. CsvManifestValidator errors, however, are properly
interpreted as non-blocking warnings (when appropriate), and errors are
made visible to users. Validate errors from CalifornicaCsvParser, on the
other hand, always cause ingest to fail without user-visible messages.