### PR TITLE
CsvManifestValidator: make 'Rights.copyrightStatus' column optional CAL-631

### DIFF
--- a/app/uploaders/csv_manifest_validator.rb
+++ b/app/uploaders/csv_manifest_validator.rb
@@ -18,7 +18,6 @@ REQUIRED_HEADERS = [
   'Title',
   'Object Type',
   'Parent ARK',
-  'Rights.copyrightStatus',
   'File Name'
 ].freeze
 
@@ -53,6 +52,7 @@ OPTIONAL_HEADERS = [
   'Project Name',
   'Publisher.publisherName',
   'Relation.isPartOf',
+  'Rights.copyrightStatus',
   'Rights.countryCreation',
   'Rights.rightsHolderContact',
   'Rights.servicesContact',


### PR DESCRIPTION
This has not been entered for some collections, so it doesn't end up in the csvs. We already map missing values to 'unknown', so requiring the header isn't necessary.