### PR TITLE
validate files are present in CSV upload

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,3 +118,7 @@ RSpec/DescribeClass:
     - 'spec/tasks/**/*'
     - 'spec/system/search_crawler_spec.rb'
     - 'spec/tasks/**/*'
+
+Style/Next:
+  Exclude:
+    - 'app/uploaders/csv_manifest_validator.rb'

--- a/spec/fixtures/csv_import/csv_files_with_problems/invalid_values.csv
+++ b/spec/fixtures/csv_import/csv_files_with_problems/invalid_values.csv
@@ -1,4 +1,4 @@
 Object Type,Title,Item ARK,Parent ARK,Rights.copyrightStatus,File Name,Type.typeOfResource
 Work,Invalid rights_statement,ark:/123/defg,ark:/123/abc,invalid rights statement,clusc_1_1_00010432a.tif,still image
-Work,Invalid resource_type,ark:/123/hijk,ark:/123/abc,copyrighted,clusc_1_1_00010433a.tif,invalid type|~|still image
-Work,Invalid resource_type #2,ark:/123/lmnop,ark:/123/abc,copyrighted|~|unknown,clusc_1_1_00010434a.tif,invalid type
+Work,Invalid resource_type,ark:/123/hijk,ark:/123/abc,copyrighted,clusc_1_1_00010432a.tif,invalid type|~|still image
+Work,Invalid resource_type #2,ark:/123/lmnop,ark:/123/abc,copyrighted|~|unknown,clusc_1_1_00010432a.tif,invalid type

--- a/spec/uploaders/csv_manifest_uploader_spec.rb
+++ b/spec/uploaders/csv_manifest_uploader_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe CsvManifestUploader, type: :model do
   let(:uploader) { csv_import.manifest }
   let(:csv_import) do
-    import = CsvImport.new(user: user)
+    import = CsvImport.new(user: user, import_file_path: fixture_path)
     File.open(csv_file) { |f| import.manifest = f }
     import
   end


### PR DESCRIPTION
Validates that files listed in a csv are present in CsvManifestValidator.manifest_uploader.model.import_file_path. If import_file_path is nil, no validation is performed and no warnings are given.

Unfortunately, when validation messages are displayed in the preview screen the CSVImport has not yet been saved to the database, and the unsaved object passed to CsvManifestValidator has manifest_uploader.model.import_file_path == nil. Thus, this functionality is not yet available.