### PR TITLE
Refactor Hyrax::CharacterizeJob spec

### DIFF
--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :file_set do
+    transient do
+      user { create(:user) }
+      content { nil }
+    end
+    after(:build) do |fs, evaluator|
+      fs.apply_depositor_metadata evaluator.user.user_key
+    end
+
+    after(:create) do |file, evaluator|
+      Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
+    end
+
+    trait :public do
+      read_groups { ["public"] }
+    end
+
+    trait :registered do
+      read_groups { ["registered"] }
+    end
+
+    factory :file_with_work do
+      after(:build) do |file, _evaluator|
+        file.title = ['testfile']
+      end
+      after(:create) do |file, evaluator|
+        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
+        create(:work, user: evaluator.user).members << file
+      end
+    end
+  end
+end

--- a/spec/jobs/hyrax/characterize_job_spec.rb
+++ b/spec/jobs/hyrax/characterize_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::CharacterizeJob do
+  context 'a row has a corrupt file', :clean, :inline_jobs do
+    let(:corrupt_file) { File.join(fixture_path, 'images', 'corrupted', 'food.tif') }
+    let(:file_set) { FactoryBot.create(:file_set) }
+    let(:original_logger) { Rails.logger }
+    let(:output) { StringIO.new }
+    let(:work) { FactoryBot.create(:work) }
+    let(:file_id) { file_set.files.first.id }
+    let(:characterization_error) { output.string }
+
+    before do
+      original_logger
+      Rails.logger = Logger.new(output)
+      Hydra::Works::AddFileToFileSet.call(file_set, File.open(corrupt_file, 'rb'), :original_file)
+      work.ordered_members << file_set
+      work.save
+      described_class.perform_now(file_set, file_id)
+    end
+
+    after do
+      Rails.logger = original_logger
+    end
+
+    it 'reports corrupt files in the log' do
+      expect(characterization_error).to match(/event: unexpected file characterization/)
+      expect(characterization_error).to match(/ark: #{Work.last.ark}/)
+      expect(characterization_error).to match(/work_id: #{Work.last.id}/)
+      expect(characterization_error).to match(/food.tif/)
+      # Different versions of FITS return different mime types
+      expect(characterization_error).to match(/mime_type: image\/tiff/).or match(/mime_type: application\/octet-stream/)
+    end
+  end
+end

--- a/spec/jobs/start_csv_import_job_spec.rb
+++ b/spec/jobs/start_csv_import_job_spec.rb
@@ -16,32 +16,4 @@ RSpec.describe StartCsvImportJob, :clean, :inline_jobs do
       expect(Work.last.members.first.files.first.metadata.mime_type.first).to match(/tiff/)
     end
   end
-
-  context 'a corrupt file', :clean do
-    let(:import_file_path) { File.join(fixture_path, 'images', 'corrupted') }
-    let(:original_logger) { Rails.logger }
-    let(:output) { StringIO.new }
-
-    before do
-      original_logger
-      Rails.logger = Logger.new(output)
-    end
-
-    after do
-      Rails.logger = original_logger
-    end
-
-    it 'writes a characterization error with expected metadata' do
-      described_class.perform_now(csv_import.id)
-      expect(Collection.count).to eq 1
-      expect(Work.count).to eq 1
-      characterization_error = output.string
-      expect(characterization_error).to match(/event: unexpected file characterization/)
-      expect(characterization_error).to match(/ark: #{Work.last.ark}/)
-      expect(characterization_error).to match(/work_id: #{Work.last.id}/)
-      expect(characterization_error).to match(/food.tif/)
-      # Different versions of FITS return different mime types
-      expect(characterization_error).to match(/mime_type: image\/tiff/).or match(/mime_type: application\/octet-stream/)
-    end
-  end
 end


### PR DESCRIPTION
Instead of testing Hyrax::CharacterizeJob via the CSV import process,
give it its own tightly focused test. This will make refactoring of the
CSV import process easier, and should make our test suite a little
faster.