### PR TITLE
Allow mapping of multiple ingest fields to a single californica field CAL-597

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,6 +119,10 @@ RSpec/DescribeClass:
     - 'spec/system/search_crawler_spec.rb'
     - 'spec/tasks/**/*'
 
+Style/BracesAroundHashParameters:
+  Exclude:
+    - 'spec/importers/californica_mapper_spec.rb'
+
 Style/Next:
   Exclude:
     - 'app/uploaders/csv_manifest_validator.rb'

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -194,7 +194,9 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   def map_field(name)
     return unless CALIFORNICA_TERMS_MAP.keys.include?(name)
 
-    metadata[CALIFORNICA_TERMS_MAP[name]]&.split(DELIMITER)
+    Array.wrap(CALIFORNICA_TERMS_MAP[name]).map do |source_field|
+      metadata[source_field]&.split(DELIMITER)
+    end.flatten.compact
   end
 
   # Determine what Collection this object should be part of.

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -117,6 +117,24 @@ RSpec.describe CalifornicaMapper do
     end
   end
 
+  describe '#map_field' do
+    let(:metadata) do
+      { 'Single.source' => 'specific',
+        'Source.one' => 'ecolog|~|next',
+        'Source.two' => 'nihilism' }
+    end
+
+    it 'maps from a single source field' do
+      stub_const('CalifornicaMapper::CALIFORNICA_TERMS_MAP', { 'single_source' => 'Single.source' })
+      expect(mapper.map_field('single_source')).to eq(['specific'])
+    end
+
+    it 'maps from a list of source fields' do
+      stub_const('CalifornicaMapper::CALIFORNICA_TERMS_MAP', { 'multi_source' => ['Source.one', 'Source.two'] })
+      expect(mapper.map_field('multi_source')).to eq(['ecolog', 'next', 'nihilism'])
+    end
+  end
+
   describe '#ark' do
     it "maps the required ark field" do
       expect(mapper.ark).to eq('ark:/21198/zz0002nq4w')


### PR DESCRIPTION
Prerequisite of CAL-597, which (after CAL-584 creates the field) will map both AltTitle.other and AltTitle.translated to alternative_title.