### PR TITLE
CAL-604 report batch import status

### DIFF
--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -19,7 +19,6 @@ class CsvImportsController < ApplicationController
   def create
     @csv_import.user = current_user
     preserve_cache
-
     if @csv_import.save
       @csv_import.queue_start_job
       redirect_to @csv_import
@@ -36,7 +35,7 @@ class CsvImportsController < ApplicationController
     end
 
     def create_params
-      params.fetch(:csv_import, {}).permit(:manifest, :import_file_path)
+      params.fetch(:csv_import, {}).permit(:manifest, :import_file_path, :manifest_records)
     end
 
     # Since we are re-rendering the form (once for
@@ -48,5 +47,6 @@ class CsvImportsController < ApplicationController
       return unless params['csv_import']
       @csv_import.manifest_cache = params['csv_import']['manifest_cache']
       @csv_import.import_file_path = params['csv_import']['import_file_path']
+      @csv_import.record_count = params['csv_import']['record_count']
     end
 end

--- a/app/views/csv_imports/_start_import_form.html.erb
+++ b/app/views/csv_imports/_start_import_form.html.erb
@@ -2,6 +2,7 @@
 
   <%= form.hidden_field :manifest_cache %>
   <%= form.hidden_field :import_file_path %>
+  <%= form.hidden_field :record_count, value: csv_import.manifest_records %>
 
   <div class="actions">
     <%= form.submit 'Start Import' %>

--- a/app/views/csv_imports/index.html.erb
+++ b/app/views/csv_imports/index.html.erb
@@ -1,21 +1,43 @@
 <p id="notice"><%= notice %></p>
-
-<h2>CSV Imports</h2>
-
-<table>
-  <thead>
-    <tr>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @csv_imports.each do |csv_import| %>
-      <tr>
-        <td><%= csv_import.id %></td>
-        <td><%= link_to 'Show', csv_import %></td>
+<div class="col-xs-12 main-header">
+  <h2>CSV Imports</h2>
+</div>
+<div class="panel-body">
+  <table class="table-condensed table-striped datatable dataTable no-footer" role="grid" data-order="[[ 1, &quot;desc&quot; ]]">
+    <thead>
+      <tr role="row">
+        <th class="sorting_desc">
+          CSV Import ID
+        </th>
+        <th>
+          Created at
+        </th>
+        <th>
+          Created by
+        </th>
+        <th>
+          Filename
+        </th>
+        <th>
+          Record Count
+        </th>
+        <th>
+          Status
+        </th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
 
+    <tbody>
+      <% @csv_imports.each do |csv_import| %>
+        <tr>
+          <td><%= link_to csv_import.id, csv_import %></td>
+          <td><%= csv_import.created_at.strftime('%e %b %Y %l:%M %p') %></td>
+          <td><%= ::User.find(csv_import.user_id).display_name || "Unknown" %></td>
+          <td><%= link_to csv_import.manifest.file.file, csv_import %></td>
+          <td><%= csv_import.record_count || "Unknown" %></td>
+          <td><%= csv_import.status || "Unknown" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -21,6 +21,10 @@
     <% end %>
   <% end %>
 
+  <%= menu.nav_link('/csv_imports',  data: { turbolinks: false }) do %>
+      <span class="fa fa-upload"></span> <span class="sidebar-action-text">CSV Import Status Reports</span>
+  <% end %>
+
   <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
       <span class="fa fa-upload"></span> <span class="sidebar-action-text">Import Content From a CSV</span>
   <% end %>

--- a/db/migrate/20190606181513_add_status_to_csv_import.rb
+++ b/db/migrate/20190606181513_add_status_to_csv_import.rb
@@ -1,0 +1,5 @@
+class AddStatusToCsvImport < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_imports, :status, :string
+  end
+end

--- a/db/migrate/20190606192158_add_record_count_to_csv_import.rb
+++ b/db/migrate/20190606192158_add_record_count_to_csv_import.rb
@@ -1,0 +1,5 @@
+class AddRecordCountToCsvImport < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_imports, :record_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190523194336) do
+ActiveRecord::Schema.define(version: 20190606192158) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -73,6 +73,8 @@ ActiveRecord::Schema.define(version: 20190523194336) do
     t.datetime "updated_at", null: false
     t.string "manifest"
     t.string "import_file_path"
+    t.string "status"
+    t.integer "record_count"
     t.index ["user_id"], name: "index_csv_imports_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -595,10 +595,7 @@ ActiveRecord::Schema.define(version: 20190523194336) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
-  add_foreign_key "collection_type_participants", "hyrax_collection_types"
   add_foreign_key "csv_imports", "users"
-  add_foreign_key "curation_concerns_operations", "users"
-  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
   add_foreign_key "permission_template_accesses", "permission_templates"

--- a/spec/factories/csv_imports.rb
+++ b/spec/factories/csv_imports.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     user { FactoryBot.create(:user) }
     manifest { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'csv_import', 'import_manifest.csv'), 'text/csv') }
     import_file_path { Rails.root.join('spec', 'fixtures') }
+    status { 'complete' }
   end
 end

--- a/spec/models/csv_import_spec.rb
+++ b/spec/models/csv_import_spec.rb
@@ -17,4 +17,14 @@ RSpec.describe CsvImport, type: :model do
     csv_import.import_file_path = path
     expect(csv_import.import_file_path).to eq path
   end
+
+  it 'has a status' do
+    csv_import.status = "complete"
+    expect(csv_import.status).to eq "complete"
+  end
+
+  it 'has a record count' do
+    csv_import.record_count = 2
+    expect(csv_import.record_count).to eq 2
+  end
 end

--- a/spec/system/csv_import_status_reports_spec.rb
+++ b/spec/system/csv_import_status_reports_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
+  context 'logged in as an admin user' do
+    let(:admin_user) { FactoryBot.create(:admin) }
+    let(:csv_import) { FactoryBot.create(:csv_import, record_count: 52) }
+
+    before do
+      login_as admin_user
+      csv_import
+    end
+
+    it 'starts the import' do
+      visit '/csv_imports'
+      expect(page).to have_content csv_import.id
+      expect(page).to have_content csv_import.manifest.filename
+      expect(page).to have_content csv_import.created_at.strftime('%e %b %Y %l:%M %p')
+      expect(page).to have_content "complete"
+      expect(page).to have_content "52"
+    end
+  end
+end

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
 
       csv_import = CsvImport.last
       expect(csv_import.import_file_path).to eq import_file_path
+      expect(csv_import.record_count).to eq 2
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
     end
   end


### PR DESCRIPTION
* Display all CsvImports, most recent first
* Put a link to that page on the admin dashboard
* Cache the number of records attached to a csv import on the object,
for faster display
* Give a CsvImport object a status field