### PR TITLE
Decrease logging level in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,9 +49,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # Use error in production for logs, debug is causing the server disk to max out before log rotation
+  config.log_level = :error
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
`california-dev` is still running out of disk space because the logs. This will reduce the logging level in prod to error.