### PR TITLE
Status report of the rows in a CSV Import

### DIFF
--- a/app/actors/hyrax/actors/work_actor.rb
+++ b/app/actors/hyrax/actors/work_actor.rb
@@ -5,7 +5,8 @@ module Hyrax
   module Actors
     class WorkActor < Hyrax::Actors::BaseActor
       def apply_save_data_to_curation_concern(env)
-        # There is no metadata field called batch_id, so remove this to prevent problems when saving this object
+        # There is no metadata field called row_id, so remove this to prevent problems when saving this object
+        env.attributes.delete(:row_id)
         env.attributes.delete(:batch_id)
         raise "Cannot set id without a valid ark" unless env.attributes["ark"]
         ark_based_id = Californica::IdGenerator.id_from_ark(env.attributes["ark"])

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -8,7 +8,9 @@ class CsvImportsController < ApplicationController
 
   def index; end
 
-  def show; end
+  def show
+    @csv_rows = CsvRow.where(csv_import_id: @csv_import.id)
+  end
 
   def new; end
 

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 class CsvRowImportJob < ActiveJob::Base
   def perform(row_id:)
-    row = CsvRow.find(row_id)
-    metadata = JSON.parse(row.metadata)
-    csv_import = CsvImport.find(row.csv_import_id)
-    import_file_path = csv_import.import_file_path
-    record = Darlingtonia::InputRecord.from(metadata: metadata, mapper: CalifornicaMapper.new(import_file_path: import_file_path))
+    @row_id = row_id
+    @row = CsvRow.find(@row_id)
+    @metadata = JSON.parse(@row.metadata)
+    @metadata = @metadata.merge(row_id: @row_id)
+    @csv_import = CsvImport.find(@row.csv_import_id)
+    import_file_path = @csv_import.import_file_path
+    record = Darlingtonia::InputRecord.from(metadata: @metadata, mapper: CalifornicaMapper.new(import_file_path: import_file_path))
 
-    collection_record_importer = ::CollectionRecordImporter.new(attributes: metadata)
-    actor_record_importer = ::ActorRecordImporter.new(attributes: metadata)
     selected_importer = if record.mapper.collection?
                           collection_record_importer
                         else
@@ -16,11 +16,19 @@ class CsvRowImportJob < ActiveJob::Base
                         end
     selected_importer.import(record: record)
 
-    row.status = 'complete'
-    row.save
+    @row.status = 'complete'
+    @row.save
   rescue => e
-    row.status = 'error'
-    row.error_messages = e.message
-    row.save
+    @row.status = 'error'
+    @row.error_messages = e.message
+    @row.save
+  end
+
+  def collection_record_importer
+    ::CollectionRecordImporter.new(attributes: @metadata)
+  end
+
+  def actor_record_importer
+    ::ActorRecordImporter.new(attributes: @metadata)
   end
 end

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -1,16 +1,52 @@
-<h2> Importing Records from a CSV File </h2>
 <p id="notice"><%= notice %></p>
+<div class="col-xs-12 main-header">
+  <h2>CSV Import <%= @csv_import.id %></h2>
+</div>
+<div class="panel-body">
+  <p>
+    <label> CSV Manifest: </label>
+    <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
+    <br />
+    <label> Uploaded by: </label>
+    <span> <%= @csv_import.user.name %> </span>
+    <br />
+    <label> Start time: </label>
+    <span> <%= @csv_import.created_at.strftime('%e %b %Y %l:%M %p') %> </span>
+    <br />
 
-<p>
-  <label> CSV Manifest: </label>
-  <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
-  <br />
-  <label> Uploaded by: </label>
-  <span> <%= @csv_import.user.name %> </span>
-  <br />
-  <label> Start time: </label>
-  <span> <%= @csv_import.created_at %> </span>
-</p>
-
-<p> TODO: Put info about the current status of the import here. </p>
-
+    <label> Queued records: </label>
+    <span> <%= @csv_import.record_count %> </span>
+  </p>
+  <table class="table-condensed table-striped datatable dataTable no-footer" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
+    <thead>
+      <tr role="row">
+        <th class="sorting_desc">
+          Row Number
+        </th>
+        <th>
+          Item Ark
+        </th>
+        <th>
+          Last Updated
+        </th>
+        <th>
+          Error message(s)
+        </th>
+        <th>
+          Status
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @csv_rows.each do |csv_row| %>
+        <tr>
+          <td><%= csv_row.row_number || "Unknown" %></td>
+          <td><%= JSON.parse(csv_row.metadata)["Item ARK"] || "Unknown" %></td>
+          <td><%= csv_row.updated_at.strftime('%e %b %Y %l:%M %p') || "Unknown" %></td>
+          <td><%= csv_row.error_messages || "" %></td>
+          <td><%= csv_row.status || "Unknown" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/spec/factories/csv_rows.rb
+++ b/spec/factories/csv_rows.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :csv_row do
-    row_number { 1 }
+    sequence(:row_number, &:to_s)
     job_id { "23452" }
     csv_import_id { "193453" }
     status { "complete" }

--- a/spec/models/csv_row_spec.rb
+++ b/spec/models/csv_row_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CsvRow, type: :model do
   subject(:csv_row) { FactoryBot.create(:csv_row) }
 
   it 'has a row number' do
-    expect(csv_row.row_number).to eq(1)
+    expect(csv_row.row_number).to be_instance_of(Integer)
   end
 
   it 'has a job id' do

--- a/spec/system/csv_import_status_show_spec.rb
+++ b/spec/system/csv_import_status_show_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
+  context 'logged in as an admin user' do
+    let(:admin_user) { FactoryBot.create(:admin) }
+    let(:csv_import) { FactoryBot.create(:csv_import, record_count: 52) }
+    let(:csv_row1) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id) }
+    let(:csv_row2) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id) }
+
+    before do
+      login_as admin_user
+      csv_import
+      csv_row1
+      csv_row2
+    end
+
+    it 'starts the import' do
+      visit "/csv_imports/#{csv_import.id}"
+      expect(page).to have_content csv_import.id
+      expect(page).to have_content csv_import.created_at.strftime('%e %b %Y %l:%M %p')
+      expect(page).to have_content "complete"
+      expect(page).to have_content "52"
+      expect(page).to have_content "here is your error"
+    end
+  end
+end

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -31,9 +31,10 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
       # After reading the warnings, the user decides
       # to continue with the import.
       click_on 'Start Import'
-      expect(page).to have_content('Importing Records from a CSV File')
-
       csv_import = CsvImport.last
+
+      expect(page).to have_content("CSV Import #{csv_import.id}")
+
       expect(csv_import.import_file_path).to eq import_file_path
       expect(csv_import.record_count).to eq 2
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)

--- a/spec/system/import_mss_from_csv_spec.rb
+++ b/spec/system/import_mss_from_csv_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe 'Importing a multi-page mss from a CSV file', :clean, type: :syst
       # After reading the warnings, the user decides
       # to continue with the import.
       click_on 'Start Import'
-      expect(page).to have_content('Importing Records from a CSV File')
-
       csv_import = CsvImport.last
+
+      expect(page).to have_content("CSV Import #{csv_import.id}")
       expect(csv_import.import_file_path).to eq import_file_path
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
     end


### PR DESCRIPTION
This PR represents the first part of CAL-605:
* Pass row id to import process so new background jobs can be tracked
* Use row_id instead of batch id and track ark in error messages

Importantly, this PR does NOT track the status of any background jobs a CSV row kicks off in deciding whether the row is complete or not. 

