### PR TITLE
Track background jobs ids in CsvRow

### DIFF
--- a/app/actors/hyrax/actors/work_actor.rb
+++ b/app/actors/hyrax/actors/work_actor.rb
@@ -5,7 +5,8 @@ module Hyrax
   module Actors
     class WorkActor < Hyrax::Actors::BaseActor
       def apply_save_data_to_curation_concern(env)
-        # There is no metadata field called batch_id, so remove this to prevent problems when saving this object
+        # There is no metadata field called row_id, so remove this to prevent problems when saving this object
+        env.attributes.delete(:row_id)
         env.attributes.delete(:batch_id)
         raise "Cannot set id without a valid ark" unless env.attributes["ark"]
         ark_based_id = Californica::IdGenerator.id_from_ark(env.attributes["ark"])

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -8,7 +8,9 @@ class CsvImportsController < ApplicationController
 
   def index; end
 
-  def show; end
+  def show
+    @csv_rows = CsvRow.where(csv_import_id: @csv_import.id)
+  end
 
   def new; end
 

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -16,10 +16,10 @@ class CsvRowImportJob < ActiveJob::Base
                         end
     selected_importer.import(record: record)
 
-    @row.status = 'complete'
+    @row.job_ids_completed << job_id
     @row.save
   rescue => e
-    @row.status = 'error'
+    @row.job_ids_errored << job_id
     @row.error_messages << e.message
     @row.save
   end

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -20,7 +20,7 @@ class CsvRowImportJob < ActiveJob::Base
     @row.save
   rescue => e
     @row.status = 'error'
-    @row.error_messages = e.message
+    @row.error_messages << e.message
     @row.save
   end
 

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 class CsvRowImportJob < ActiveJob::Base
   def perform(row_id:)
-    row = CsvRow.find(row_id)
-    metadata = JSON.parse(row.metadata)
-    csv_import = CsvImport.find(row.csv_import_id)
-    import_file_path = csv_import.import_file_path
-    record = Darlingtonia::InputRecord.from(metadata: metadata, mapper: CalifornicaMapper.new(import_file_path: import_file_path))
+    @row_id = row_id
+    @row = CsvRow.find(@row_id)
+    @metadata = JSON.parse(@row.metadata)
+    @metadata = @metadata.merge(row_id: @row_id)
+    @csv_import = CsvImport.find(@row.csv_import_id)
+    import_file_path = @csv_import.import_file_path
+    record = Darlingtonia::InputRecord.from(metadata: @metadata, mapper: CalifornicaMapper.new(import_file_path: import_file_path))
 
-    collection_record_importer = ::CollectionRecordImporter.new(attributes: metadata)
-    actor_record_importer = ::ActorRecordImporter.new(attributes: metadata)
     selected_importer = if record.mapper.collection?
                           collection_record_importer
                         else
@@ -16,11 +16,19 @@ class CsvRowImportJob < ActiveJob::Base
                         end
     selected_importer.import(record: record)
 
-    row.status = 'complete'
-    row.save
+    @row.status = 'complete'
+    @row.save
   rescue => e
-    row.status = 'error'
-    row.error_messages = e.message
-    row.save
+    @row.status = 'error'
+    @row.error_messages = e.message
+    @row.save
+  end
+
+  def collection_record_importer
+    ::CollectionRecordImporter.new(attributes: @metadata)
+  end
+
+  def actor_record_importer
+    ::ActorRecordImporter.new(attributes: @metadata)
   end
 end

--- a/app/models/csv_row.rb
+++ b/app/models/csv_row.rb
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 class CsvRow < ApplicationRecord
+  serialize :job_ids_queued, Array
+  serialize :job_ids_completed, Array
+  serialize :job_ids_errored, Array
+  serialize :error_messages, Array
 end

--- a/app/models/csv_row.rb
+++ b/app/models/csv_row.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 class CsvRow < ApplicationRecord
-  serialize :job_ids_queued, Array
-  serialize :job_ids_completed, Array
-  serialize :job_ids_errored, Array
+  serialize :job_ids_queued, Set
+  serialize :job_ids_completed, Set
+  serialize :job_ids_errored, Set
   serialize :error_messages, Array
+
+  def status
+    return "error" unless job_ids_errored.empty?
+    return "queued" unless queued_but_not_completed.empty?
+    return "complete" if queued_but_not_completed.empty?
+    "unknown"
+  end
+
+  def queued_but_not_completed
+    job_ids_queued - job_ids_completed
+  end
 end

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -1,16 +1,52 @@
-<h2> Importing Records from a CSV File </h2>
 <p id="notice"><%= notice %></p>
+<div class="col-xs-12 main-header">
+  <h2>CSV Import <%= @csv_import.id %></h2>
+</div>
+<div class="panel-body">
+  <p>
+    <label> CSV Manifest: </label>
+    <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
+    <br />
+    <label> Uploaded by: </label>
+    <span> <%= @csv_import.user.name %> </span>
+    <br />
+    <label> Start time: </label>
+    <span> <%= @csv_import.created_at.strftime('%e %b %Y %l:%M %p') %> </span>
+    <br />
 
-<p>
-  <label> CSV Manifest: </label>
-  <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
-  <br />
-  <label> Uploaded by: </label>
-  <span> <%= @csv_import.user.name %> </span>
-  <br />
-  <label> Start time: </label>
-  <span> <%= @csv_import.created_at %> </span>
-</p>
-
-<p> TODO: Put info about the current status of the import here. </p>
-
+    <label> Queued records: </label>
+    <span> <%= @csv_import.record_count %> </span>
+  </p>
+  <table class="table-condensed table-striped datatable dataTable no-footer" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
+    <thead>
+      <tr role="row">
+        <th class="sorting_desc">
+          Row Number
+        </th>
+        <th>
+          Item Ark
+        </th>
+        <th>
+          Last Updated
+        </th>
+        <th>
+          Error message(s)
+        </th>
+        <th>
+          Status
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @csv_rows.each do |csv_row| %>
+        <tr>
+          <td><%= csv_row.row_number || "Unknown" %></td>
+          <td><%= JSON.parse(csv_row.metadata)["Item ARK"] || "Unknown" %></td>
+          <td><%= csv_row.updated_at.strftime('%e %b %Y %l:%M %p') || "Unknown" %></td>
+          <td><%= csv_row.error_messages || "" %></td>
+          <td><%= csv_row.status || "Unknown" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/db/migrate/20190607170700_add_job_ids_to_csv_row.rb
+++ b/db/migrate/20190607170700_add_job_ids_to_csv_row.rb
@@ -1,0 +1,7 @@
+class AddJobIdsToCsvRow < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_rows, :job_ids_queued, :text
+    add_column :csv_rows, :job_ids_completed, :text
+    add_column :csv_rows, :job_ids_errored, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190606192158) do
+ActiveRecord::Schema.define(version: 20190607170700) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -87,6 +87,9 @@ ActiveRecord::Schema.define(version: 20190606192158) do
     t.text "metadata"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "job_ids_queued"
+    t.text "job_ids_completed"
+    t.text "job_ids_errored"
   end
 
   create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -597,7 +600,10 @@ ActiveRecord::Schema.define(version: 20190606192158) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
   add_foreign_key "csv_imports", "users"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
   add_foreign_key "permission_template_accesses", "permission_templates"

--- a/spec/factories/csv_rows.rb
+++ b/spec/factories/csv_rows.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :csv_row do
-    row_number { 1 }
+    sequence(:row_number, &:to_s)
     job_id { "23452" }
     csv_import_id { "193453" }
     status { "complete" }

--- a/spec/factories/csv_rows.rb
+++ b/spec/factories/csv_rows.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     sequence(:row_number, &:to_s)
     job_id { "23452" }
     csv_import_id { "193453" }
-    status { "complete" }
     error_messages { ["here is your error"] }
     metadata do
       {

--- a/spec/factories/csv_rows.rb
+++ b/spec/factories/csv_rows.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     job_id { "23452" }
     csv_import_id { "193453" }
     status { "complete" }
-    error_messages { "here is your error" }
+    error_messages { ["here is your error"] }
     metadata do
       {
         "Project Name" => "Ethiopic Manuscripts",

--- a/spec/jobs/csv_row_import_job_spec.rb
+++ b/spec/jobs/csv_row_import_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CsvRowImportJob, :clean do
       described_class.perform_now(row_id: csv_row.id)
       csv_row.reload
       expect(csv_row.status).to eq('error')
-      expect(csv_row.error_messages).to eq 'Cannot set id without a valid ark'
+      expect(csv_row.error_messages).to contain_exactly 'Cannot set id without a valid ark'
     end
   end
 end

--- a/spec/models/csv_row_spec.rb
+++ b/spec/models/csv_row_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe CsvRow, type: :model do
   subject(:csv_row) { FactoryBot.create(:csv_row) }
+  let(:job_id) { "4344db9d-eef0-46c2-a3f6-5ebc19043b76" }
 
   it 'has a row number' do
     expect(csv_row.row_number).to be_instance_of(Integer)
@@ -20,11 +21,27 @@ RSpec.describe CsvRow, type: :model do
   end
 
   it 'has a error messages' do
-    expect(csv_row.error_messages).to eq('here is your error')
+    csv_row.error_messages << 'another error'
+    expect(csv_row.error_messages).to contain_exactly('here is your error', 'another error')
   end
 
   it 'has metadata that is parsable as json' do
     metadata_hash = JSON.parse(csv_row.metadata)
     expect(metadata_hash['Item ARK']).to eq('21198/zz001pz6jq')
+  end
+
+  it 'collects job ids queued' do
+    csv_row.job_ids_queued << job_id
+    expect(csv_row.job_ids_queued).to contain_exactly(job_id)
+  end
+
+  it 'collects job ids completed' do
+    csv_row.job_ids_completed << job_id
+    expect(csv_row.job_ids_completed).to contain_exactly(job_id)
+  end
+
+  it 'collects job ids errored' do
+    csv_row.job_ids_errored << job_id
+    expect(csv_row.job_ids_errored).to contain_exactly(job_id)
   end
 end

--- a/spec/models/csv_row_spec.rb
+++ b/spec/models/csv_row_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe CsvRow, type: :model do
     expect(csv_row.csv_import_id).to eq('193453')
   end
 
-  it 'has a status' do
-    expect(csv_row.status).to eq('complete')
-  end
-
   it 'has a error messages' do
     csv_row.error_messages << 'another error'
     expect(csv_row.error_messages).to contain_exactly('here is your error', 'another error')
@@ -30,18 +26,37 @@ RSpec.describe CsvRow, type: :model do
     expect(metadata_hash['Item ARK']).to eq('21198/zz001pz6jq')
   end
 
-  it 'collects job ids queued' do
-    csv_row.job_ids_queued << job_id
-    expect(csv_row.job_ids_queued).to contain_exactly(job_id)
-  end
+  context 'tracking background jobs' do
+    context 'collecting job ids' do
+      it 'collects job ids queued' do
+        csv_row.job_ids_queued << job_id
+        expect(csv_row.job_ids_queued).to contain_exactly(job_id)
+      end
 
-  it 'collects job ids completed' do
-    csv_row.job_ids_completed << job_id
-    expect(csv_row.job_ids_completed).to contain_exactly(job_id)
-  end
+      it 'collects job ids completed' do
+        csv_row.job_ids_completed << job_id
+        expect(csv_row.job_ids_completed).to contain_exactly(job_id)
+      end
 
-  it 'collects job ids errored' do
-    csv_row.job_ids_errored << job_id
-    expect(csv_row.job_ids_errored).to contain_exactly(job_id)
+      it 'collects job ids errored' do
+        csv_row.job_ids_errored << job_id
+        expect(csv_row.job_ids_errored).to contain_exactly(job_id)
+      end
+    end
+    context 'determining status' do
+      it 'has an error status if any job ids are in an error state' do
+        csv_row.job_ids_errored << job_id
+        expect(csv_row.status).to eq "error"
+      end
+      it 'has a queued status if there are ids queued but not yet complete' do
+        csv_row.job_ids_queued << job_id
+        expect(csv_row.status).to eq "queued"
+      end
+      it 'has a complete status if all job ids queued have registered as complete' do
+        csv_row.job_ids_queued << job_id
+        csv_row.job_ids_completed << job_id
+        expect(csv_row.status).to eq "complete"
+      end
+    end
   end
 end

--- a/spec/models/csv_row_spec.rb
+++ b/spec/models/csv_row_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CsvRow, type: :model do
   subject(:csv_row) { FactoryBot.create(:csv_row) }
 
   it 'has a row number' do
-    expect(csv_row.row_number).to eq(1)
+    expect(csv_row.row_number).to be_instance_of(Integer)
   end
 
   it 'has a job id' do

--- a/spec/system/csv_import_status_show_spec.rb
+++ b/spec/system/csv_import_status_show_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
+  context 'logged in as an admin user' do
+    let(:admin_user) { FactoryBot.create(:admin) }
+    let(:csv_import) { FactoryBot.create(:csv_import, record_count: 52) }
+    let(:csv_row1) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id) }
+    let(:csv_row2) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id) }
+
+    before do
+      login_as admin_user
+      csv_import
+      csv_row1
+      csv_row2
+    end
+
+    it 'starts the import' do
+      visit "/csv_imports/#{csv_import.id}"
+      expect(page).to have_content csv_import.id
+      expect(page).to have_content csv_import.created_at.strftime('%e %b %Y %l:%M %p')
+      expect(page).to have_content "complete"
+      expect(page).to have_content "52"
+      expect(page).to have_content "here is your error"
+    end
+  end
+end

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -31,9 +31,10 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
       # After reading the warnings, the user decides
       # to continue with the import.
       click_on 'Start Import'
-      expect(page).to have_content('Importing Records from a CSV File')
-
       csv_import = CsvImport.last
+
+      expect(page).to have_content("CSV Import #{csv_import.id}")
+
       expect(csv_import.import_file_path).to eq import_file_path
       expect(csv_import.record_count).to eq 2
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)

--- a/spec/system/import_mss_from_csv_spec.rb
+++ b/spec/system/import_mss_from_csv_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe 'Importing a multi-page mss from a CSV file', :clean, type: :syst
       # After reading the warnings, the user decides
       # to continue with the import.
       click_on 'Start Import'
-      expect(page).to have_content('Importing Records from a CSV File')
-
       csv_import = CsvImport.last
+
+      expect(page).to have_content("CSV Import #{csv_import.id}")
       expect(csv_import.import_file_path).to eq import_file_path
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
     end


### PR DESCRIPTION
* CsvRow should track what job ids have been queued, and which ones have
completed or errored.

* CsvRow should treat errors as an array, because there might be more than
one error reported for a given row.

* Instead of CsvRow status being a static string, it is determined by
looking at what background jobs have been queued, completed, and
errored.