### PR TITLE
Generate IIIF Manifest for works with ChildWorks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,8 @@ Metrics/BlockLength:
     - 'lib/tasks/ingest.rake'
     - 'lib/tasks/derivatives.rake'
     - app/models/ucla_metadata.rb
-
+    - app/views/manifest.json.jbuilder
+    
 Metrics/CyclomaticComplexity:
   Enabled: true
   Exclude:
@@ -91,6 +92,10 @@ RSpec/ExampleLength:
     - 'spec/jobs/mss_csv_import_job_spec.rb'
     - 'spec/forms/hyrax/work_form_spec.rb'
     - 'spec/models/concerns/discoverable_spec.rb'
+    - spec/jobs/start_csv_import_job_spec.rb
+    - spec/jobs/mss_csv_import_job_spec.rb
+    - spec/views/manifest.json.jbuilder_spec.rb
+
 
 RSpec/LetSetup:
   Enabled: false

--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -21,5 +21,21 @@ module Hyrax
       Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
       after_destroy_response(title)
     end
+
+    def manifest_builder
+      curation_concern = _curation_concern_type.find(params[:id]) unless curation_concern
+      builder_service = Californica::ManifestBuilderService.new(curation_concern: curation_concern)
+      @sets = builder_service.sets
+      @solr_doc = ::SolrDocument.find(curation_concern.id)
+      @root_url = "#{request.protocol}#{request.host_with_port}/concern/works/#{@solr_doc.id}/manifest"
+      render '/manifest.json'
+    end
+
+    def manifest
+      headers['Access-Control-Allow-Origin'] = '*'
+      curation_concern = _curation_concern_type.find(params[:id]) unless curation_concern
+      authorize! :show, curation_concern
+      manifest_builder
+    end
   end
 end

--- a/app/services/californica/child_work_service.rb
+++ b/app/services/californica/child_work_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Californica
+  class ChildWorkService
+    def child_works(member_ids_ssim:)
+      return [] if member_ids_ssim.nil?
+      member_ids_ssim.select do |id|
+        solr_doc = SolrDocument.find(id)
+        solr_doc[:has_model_ssim] == ['Work'] ||
+          solr_doc[:has_model_ssim] == ['ChildWork']
+      end
+    end
+  end
+end

--- a/app/services/californica/manifest_builder_service.rb
+++ b/app/services/californica/manifest_builder_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Californica
+  class ManifestBuilderService
+    def initialize(curation_concern:)
+      @curation_concern = curation_concern
+      @child_works = @curation_concern.ordered_members.to_a.select { |member| member.class == ChildWork || member.class == Work }
+      @file_sets = @curation_concern.ordered_members.to_a.select { |member| member.class == FileSet }
+    end
+
+    def sets
+      sets = if @child_works.length >= 1
+               @child_works.each(&:file_sets) + @file_sets.each(&:files)
+             else
+               @file_sets.each(&:files)
+             end
+      sets
+    end
+  end
+end

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,0 +1,11 @@
+<% has_child_works = !Californica::ChildWorkService.new.child_works(member_ids_ssim: SolrDocument.find(presenter.id)[:member_ids_ssim]).empty? %>
+<% if presenter.representative_id.present? && presenter.representative_presenter.present? || has_child_works %>
+    <% if defined?(viewer) && viewer || has_child_works %>
+	<%= iiif_viewer_display presenter %>
+    <% else %>
+	<%= media_display presenter.representative_presenter %>
+    <% end %>
+<% else %>
+    <%= image_tag 'default.png', class: "canonical-image" %>
+<% end %>
+

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,0 +1,55 @@
+<% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
+<div class="row work-type">
+  <div class="col-sm-12">
+    <%= render 'work_type', presenter: @presenter %>
+  </div>
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <%= render 'work_title', presenter: @presenter %>
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <div class="row">
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+         
+            <div class="col-sm-12">
+              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+            </div>
+          <div class="col-sm-3 text-center">
+            
+            <%= render 'citations', presenter: @presenter %>
+            <%= render 'social_media' %>
+          </div>
+          <div class="col-sm-9">
+            <%= render 'work_description', presenter: @presenter %>
+            <%= render 'metadata', presenter: @presenter %>
+          </div>
+        </div>
+      </div>
+    </div><!-- /panel -->
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><%= t('hyrax.base.show.relationships') %></h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'relationships', presenter: @presenter %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><%= t('.items') %></h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'items', presenter: @presenter %>
+      </div>
+    </div>
+
+    <%# TODO: we may consider adding these partials in the future %>
+    <%# = render 'sharing_with', presenter: @presenter %>
+    <%# = render 'user_activity', presenter: @presenter %>
+
+  </div>
+</div>

--- a/app/views/manifest.json.jbuilder
+++ b/app/views/manifest.json.jbuilder
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'cgi'
+
+json.set! :@context, 'http://iiif.io/api/presentation/2/context.json'
+json.set! :@type, 'sc:Manifest'
+json.set! :@id, @root_url
+json.label @solr_doc.title.first
+json.description @solr_doc.description.first
+
+json.sequences [''] do
+  json.set! :@type, 'sc:Sequence'
+  json.set! :@id, "#{@root_url}/sequence/normal"
+  json.canvases @sets do |child|
+    json.set! :@id, "#{@root_url}/canvas/#{child.id}"
+    json.set! :@type, 'sc:Canvas'
+    json.label child.title.first
+    json.description child.description.first
+    json.width 640
+    json.height 480
+    json.images [child] do |child_image|
+      file_set_id = if child_image.try(:file_sets)
+                      child_image.file_sets.first.id
+                    else
+                      child_image.id
+                    end
+
+      original_file = ::FileSet.find(file_set_id).original_file
+
+      url = Hyrax.config.iiif_image_url_builder.call(
+        original_file.id,
+        request.base_url,
+        Hyrax.config.iiif_image_size_default
+      )
+
+      json.set! :@type, 'oa:Annotation'
+      json.motivation 'sc:painting'
+      json.resource do
+        json.set! :@type, 'dctypes:Image'
+        json.set! :@id, url
+        json.width 640
+        json.height 480
+        json.service do
+          json.set! :@context, 'http://iiif.io/api/image/2/context.json'
+          json.set! :@id, "#{request.base_url}/images/#{CGI.escape(original_file.id)}"
+          json.profile 'http://iiif.io/api/image/2/level2.json'
+        end
+      end
+      json.on "#{request.base_url}/concern/works/#{@solr_doc.id}/manifest/canvas/#{child.id}"
+    end
+  end
+end

--- a/spec/controllers/hyrax/works_controller_spec.rb
+++ b/spec/controllers/hyrax/works_controller_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::WorksController, type: :controller do
+  let(:work) { FactoryBot.create(:work) }
+  describe "GET #manifest" do
+    it "returns http success" do
+      get :manifest, params: { id: work.id, format: 'json' }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/services/californica/child_work_service_spec.rb
+++ b/spec/services/californica/child_work_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Californica::ChildWorkService do
+  let(:work) { FactoryBot.create(:work) }
+  let(:work2) { FactoryBot.create(:work) }
+  let(:cws) { described_class.new }
+  before do
+    work.ordered_members << work2
+    work.save!
+    work2.save!
+  end
+
+  describe '#child_works' do
+    it 'returns an array of members that are Work or ChildWork' do
+      expect(cws.child_works(member_ids_ssim: SolrDocument.find(work.id)[:member_ids_ssim])).to eq([work2.id])
+    end
+  end
+end

--- a/spec/services/californica/manifest_builder_service_spec.rb
+++ b/spec/services/californica/manifest_builder_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Californica::ManifestBuilderService do
+  let(:work) { FactoryBot.create(:work) }
+  let(:work2) { FactoryBot.create(:work) }
+  let(:work_with_file_sets) { FactoryBot.create(:work) }
+  let(:service) { described_class.new(curation_concern: work) }
+  let(:service_with_file_sets) { described_class.new(curation_concern: work_with_file_sets) }
+  let(:file_set) { FactoryBot.create(:file_set) }
+
+  describe '#sets' do
+    it 'returns the set of works needed to create a manifest' do
+      work.ordered_members << work2
+      expect(service.sets.first.class).to eq Work
+    end
+
+    it 'returns the set of filsets needed to create a manifest' do
+      work_with_file_sets.ordered_members << file_set
+      expect(service_with_file_sets.sets.first.class).to eq FileSet
+    end
+  end
+end

--- a/spec/system/display_multipage_mss_spec_manual.rb
+++ b/spec/system/display_multipage_mss_spec_manual.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Display a Multipage Manuscript', :clean, :inline_jobs, type: :system, js: true do
+  let(:csv_file) { File.join(fixture_path, 'csv_import', 'multipage_mss', 'mss_sample.csv') }
+  let(:import_file_path) { File.join(fixture_path, 'images', 'ethiopian_mss').to_s }
+  let(:csv_import) { FactoryBot.create(:csv_import, user: user, manifest: manifest, import_file_path: import_file_path) }
+  let(:manifest) { Rack::Test::UploadedFile.new(Rails.root.join(csv_file), 'text/csv') }
+  let(:user) { FactoryBot.create(:admin) }
+
+  before do
+    StartCsvImportJob.perform_now(csv_import.id)
+  end
+
+  context "as an admin" do
+    it "displays expected fields" do
+      login_as user
+      work = Work.last
+      expect(work.ordered_member_ids).to eq ["rm6zp100zz-89112", "qj6zp100zz-89112", "7k6zp100zz-89112"]
+      visit("/concern/works/#{work.id}")
+      expect(page).to have_content work.title.first
+      expect(page.html).to match(/uv viewer/)
+    end
+  end
+end

--- a/spec/system/edit_visibility_spec.rb
+++ b/spec/system/edit_visibility_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Edit the visibility for a work', :clean, type: :system, js: true
       click_on 'Save changes'
 
       # When the show page loads, it should have the new visibility
-      expect(page).to have_current_path(hyrax_work_path(work, locale: I18n.locale))
+      expect(page).to have_current_path(hyrax_work_path(work, locale: I18n.locale)).or(hyrax_work_path(work))
       expect(page).to have_content 'Discovery'
     end
   end

--- a/spec/views/manifest.json.jbuilder_spec.rb
+++ b/spec/views/manifest.json.jbuilder_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "manifest", type: :view do
+  let(:work) { FactoryBot.create(:work) }
+  let(:file_set) { FactoryBot.create(:file_set) }
+  let(:solr_doc) { SolrDocument.find(work.id) }
+  let(:sets) { Californica::ManifestBuilderService.new(curation_concern: work).sets }
+  let(:manifest) { File.open(Rails.root.join('spec', 'fixtures', 'manifests', 'manifest.json')) }
+
+  it "displays a valid IIIF Presentation API manifest" do
+    assign(:root_url, 'http://localhost:3000/manifest')
+    assign(:solr_doc, solr_doc)
+    assign(:sets, sets)
+
+    Hydra::Works::UploadFileToFileSet.call(file_set, File.open(Rails.root.join('spec', 'fixtures', 'images', 'good', 'food.tif')))
+    work.ordered_members << file_set
+    render
+    json = JSON.parse(rendered)
+
+    expect(json['label']).to eq work.title.first
+    expect(json['description']).to eq work.description.first
+    expect(json["@context"]).to eq "http://iiif.io/api/presentation/2/context.json"
+    expect(json["@id"]).to eq "http://localhost:3000/manifest"
+    expect(json["@type"]).to eq "sc:Manifest"
+    expect(json["sequences"][0]["@type"]).to eq "sc:Sequence"
+    expect(json["sequences"][0]["canvases"]).not_to be nil
+  end
+end


### PR DESCRIPTION
The current views and libraries that generate the IIIF manifest
and display the UV interface assume that the the
`Work` is structured with an attached `FileSet` not additional
works. The first `Work` requires an attached `FileSet` or
it will not display.

The overrides the generation of the manifest so that
first `Work` will generate a manifest even if it  does
not have an image/FileSet attached to it.

This is done with a JBuilder view that the manifest
is genreated from.

Doing it this way it significantly faster. An Ethiopic manuscript
was taking 5 minutes to genrate a manifest. This is down to 1 minute.

That's still too slow, but it is still a large reduction.

Connected to CAL-638