### PR TITLE
use 'ignore_query: true' to ignore the locale part of the path in spec

### DIFF
--- a/spec/system/edit_visibility_spec.rb
+++ b/spec/system/edit_visibility_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe 'Edit the visibility for a work', :clean, type: :system, js: true
       click_on 'Save changes'
 
       # When the show page loads, it should have the new visibility
-      path_without_locale = current_path.gsub(/\?.*/, '')
-      expect(path_without_locale).to eq hyrax_work_path(work)
+      expect(page).to have_current_path(hyrax_work_path(work), ignore_query: true)
       expect(page).to have_content 'Discovery'
     end
   end


### PR DESCRIPTION
This should be functionally equivalent to https://github.com/UCLALibrary/californica/pull/633, but makes the code a bit cleaner by passing the ignore_query: true argument to the capybara assertion method, instead of stripping the query parameters with a regex.

I wouldn't have bothered, but I had already been looking at the issue and discovered this option around the same time @val99erie submitted her PR633.