### PR TITLE
Fixed a problem with access controls in a FileSet record. Part of story 608.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Metrics/CyclomaticComplexity:
     - app/uploaders/csv_manifest_validator.rb
     - app/importers/actor_record_importer.rb
     - app/importers/californica_csv_parser.rb
+    - app/models/concerns/discoverable.rb
 
 Metrics/LineLength:
   Exclude:
@@ -68,6 +69,7 @@ Metrics/MethodLength:
     - 'app/importers/csv_validator.rb'
     - app/uploaders/csv_manifest_validator.rb
     - app/indexers/collection_indexer.rb
+    - app/models/concerns/discoverable.rb
 
 Metrics/PerceivedComplexity:
   Enabled: true
@@ -75,6 +77,7 @@ Metrics/PerceivedComplexity:
     - app/importers/actor_record_importer.rb
     - app/uploaders/csv_manifest_validator.rb
     - app/importers/californica_csv_parser.rb
+    - app/models/concerns/discoverable.rb
 
 RSpec/AnyInstance:
   Enabled: false
@@ -95,7 +98,7 @@ RSpec/ExampleLength:
     - spec/jobs/start_csv_import_job_spec.rb
     - spec/jobs/mss_csv_import_job_spec.rb
     - spec/views/manifest.json.jbuilder_spec.rb
-
+    - 'spec/jobs/inherit_permissions_job_spec.rb'
 
 RSpec/LetSetup:
   Enabled: false

--- a/app/models/concerns/discoverable.rb
+++ b/app/models/concerns/discoverable.rb
@@ -53,4 +53,36 @@ module Discoverable
     super
     set_discover_groups([], represented_visibility)
   end
+
+  def permissions_attributes=(attributes_collection)
+    if attributes_collection.is_a? Hash
+      keys = attributes_collection.keys
+      attributes_collection = if keys.include?('id') || keys.include?(:id)
+                                Array(attributes_collection)
+                              else
+                                attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
+                              end
+    end
+
+    attributes_collection = attributes_collection.map(&:with_indifferent_access)
+    attributes_collection.each do |prop|
+      existing = case prop[:type]
+                 when 'group'
+                   search_by_type(:group)
+                 when 'person'
+                   search_by_type(:person)
+                 end
+
+      next if existing.blank?
+
+      # This is the part we are overriding in californica
+      selected = existing.find { |perm| (perm.agent_name == prop[:name]) && (perm.access == prop[:access]) }
+
+      prop['id'] = selected.id if selected
+    end
+
+    clean_collection = remove_bad_deletes(attributes_collection)
+
+    self.permissions_attributes_without_uniqueness = clean_collection
+  end
 end

--- a/spec/jobs/inherit_permissions_job_spec.rb
+++ b/spec/jobs/inherit_permissions_job_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe InheritPermissionsJob, :clean do
+  let(:work) do
+    w = Work.new(title: ['A'], ark: 'ark:/123/work', visibility: work_vis)
+    w.members = [fs]
+    w.save!
+    w
+  end
+
+  let(:fs) { FileSet.create(visibility: fs_vis) }
+  let(:work_vis) { 'open' }
+  let(:fs_vis) { 'discovery' }
+
+  # This spec is meant to test the override of the
+  # "permissions_attributes=" method from the
+  # hydra-access-controls gem.
+  describe 'when work has "open" and fileset has "discovery"' do
+    it 'copies the permissions from the parent work' do
+      # Expected starting state: fileset doesn't match parent work.
+      expect(work.edit_groups).to eq []
+      expect(fs.edit_groups).to eq []
+
+      expect(work.read_groups).to eq ['public']
+      expect(fs.read_groups).to eq []
+
+      expect(work.discover_groups).to eq []
+      expect(fs.discover_groups).to eq ['public']
+
+      expect(work.visibility).to eq 'open'
+      expect(fs.visibility).to eq 'discovery'
+
+      # Run the job
+      InheritPermissionsJob.perform_now(work)
+      work.reload
+      fs.reload
+
+      # Check the resulting state: fileset should match the parent work
+      expect(work.edit_groups).to eq []
+      expect(fs.edit_groups).to eq []
+
+      expect(work.read_groups).to eq ['public']
+      expect(fs.read_groups).to eq ['public']
+
+      expect(work.discover_groups).to eq []
+      expect(fs.discover_groups).to eq []
+
+      expect(work.visibility).to eq 'open'
+      expect(fs.visibility).to eq 'open'
+    end
+  end
+end


### PR DESCRIPTION
I noticed this problem in the UI: when you change the visibility of a
work record, it gives you the option to apply those changes to all the
child records.  If you select 'yes' background jobs run to update all
the attached FileSet records.  But in some situations the resulting
visibility for the FileSets didn't match the parent work.

The problem was caused by an assumption in the hydra-access-controls
gem that caused it to incorrectly match on some access control records
that it was selecting for removal.  Because we are overriding visibility
in Californica, that assumption is no longer true.  I'll take a closer
look at the hydra-access-controls gem later and decide if we should file
a bug against it, but for now, overriding the "permissions_attributes="
method from that gem allows us to fix the invalid assumption.

I added a spec for "inherit_permissions_job_spec", which tests the exact
problem at a higher level than a unit test would.

I added exclusions for this file in rubocop.  Since this method is an override, I want to keep it as similar as possible to how it appears in the gem, so that we can more easily compare the override to the original.