### PR TITLE
Initial caching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,3 +139,7 @@ Style/BracesAroundHashParameters:
 Style/Next:
   Exclude:
     - 'app/uploaders/csv_manifest_validator.rb'
+
+Style/IdenticalConditionalBranches:
+  Exclude:
+    - 'app/controllers/hyrax/works_controller.rb'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - fits
     env_file:
       - ./.env.sample
+    stdin_open: true
+    tty: true
     environment:
       DATABASE_HOST: db
       FEDORA_URL: http://fedora:8080/rest

--- a/spec/controllers/hyrax/works_controller_spec.rb
+++ b/spec/controllers/hyrax/works_controller_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Hyrax::WorksController, type: :controller do
   let(:work) { FactoryBot.create(:work) }
   describe "GET #manifest" do
     it "returns http success" do
+      work.title = ["Changes"]
+      work.date_modified = '09-09-1999'
+      work.save!
       get :manifest, params: { id: work.id, format: 'json' }
       expect(response).to have_http_status(:success)
     end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     subject { [] << FFaker::Education.major }
     description { [] << FFaker::Lorem.paragraph }
     visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    date_modified { '09-09-1999' }
   end
 end


### PR DESCRIPTION
Cache the initial JSON manifest in Redis using
a key derived from the last modified time and the
id. That way the cache will be busted when the
work is modified.

This also sets the `Cache-Control` header for
the JSON response so that the browser also
caches the JSON for 24 hours (this can be
busted by using Shift-Refresh to reload
the page).

The commit also includes the changes that were made
to ursus to allow using `byebug` in the docker environment.

Connected to CAL-639