### PR TITLE
Undefine constant to avoid confusing warning message. Jira 608

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -3,6 +3,7 @@
 # Override this constant from the hyrax gem so that we
 # can add the "discovery" visibility to Californica.
 Californica::Application.config.after_initialize do
+  Hyrax::PermissionBadge.send(:remove_const, :VISIBILITY_LABEL_CLASS)
   Hyrax::PermissionBadge::VISIBILITY_LABEL_CLASS = {
     authenticated: "label-info",
     embargo: "label-warning",


### PR DESCRIPTION
We redefine the Hyrax::PermissionBadge::VISIBILITY_LABEL_CLASS constant
to add a new value to "visibility", but redefining a constant in ruby
will cause a warning message like:
already initialized constant Hyrax::PermissionBadge::VISIBILITY_LABEL_CLASS

This code undefines the constant before setting it to avoid that warning
message.