### PR TITLE
Index the original file name in Solr

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'db/**/*.rb'
     - 'vendor/**/*'
     - 'tmp/**/*'
+    - 'config/initializers/file_set_indexer.rb'
 
 Metrics/AbcSize:
   Enabled: true

--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -50,8 +50,8 @@ module Hyrax
     private
 
       def cache_key
-        return Time.zone.now.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + @solr_doc[:id] unless @solr_doc[:date_modified_ssi]
-        @solr_doc[:date_modified_ssi].to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + @solr_doc[:id]
+        return Time.zone.now.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + @solr_doc[:id] unless @solr_doc[:date_modified_dtsi]
+        @solr_doc[:date_modified_dtsi].to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + @solr_doc[:id]
       end
   end
 end

--- a/app/views/manifest.json.jbuilder
+++ b/app/views/manifest.json.jbuilder
@@ -24,10 +24,15 @@ json.sequences [''] do
                       child_image.id
                     end
 
-      original_file = ::FileSet.find(file_set_id).original_file
+      solr_file_id = SolrDocument.find(file_set_id)[:original_filename_ssim].first
+      original_file = if solr_file_id
+                        solr_file_id
+                      else
+                        ::FileSet.find(file_set_id).original_file.id
+                      end
 
       url = Hyrax.config.iiif_image_url_builder.call(
-        original_file.id,
+        original_file,
         request.base_url,
         Hyrax.config.iiif_image_size_default
       )
@@ -41,7 +46,7 @@ json.sequences [''] do
         json.height 480
         json.service do
           json.set! :@context, 'http://iiif.io/api/image/2/context.json'
-          json.set! :@id, "#{request.base_url}/images/#{CGI.escape(original_file.id)}"
+          json.set! :@id, "#{request.base_url}/images/#{CGI.escape(original_file)}"
           json.profile 'http://iiif.io/api/image/2/level2.json'
         end
       end

--- a/config/initializers/file_set_indexer.rb
+++ b/config/initializers/file_set_indexer.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+module Hyrax
+  class FileSetIndexer < ActiveFedora::IndexingService
+    include Hyrax::IndexesThumbnails
+    include Hyrax::IndexesBasicMetadata
+    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
+
+    def generate_solr_document
+      super.tap do |solr_doc|
+        solr_doc['hasRelatedMediaFragment_ssim'] = object.representative_id
+        solr_doc['hasRelatedImage_ssim'] = object.thumbnail_id
+        # Label is the actual file name. It's not editable by the user.
+        solr_doc['label_tesim'] = object.label
+        solr_doc['label_ssi']   = object.label
+        solr_doc['file_format_tesim'] = file_format
+        solr_doc['file_format_sim']   = file_format
+        solr_doc['file_size_lts'] = object.file_size[0]
+        solr_doc['all_text_timv'] = object.extracted_text.content if object.extracted_text.present?
+        solr_doc['height_is'] = Integer(object.height.first) if object.height.present?
+        solr_doc['width_is']  = Integer(object.width.first) if object.width.present?
+        solr_doc['visibility_ssi'] = object.visibility
+        solr_doc['mime_type_ssi']  = object.mime_type
+        # Index the Fedora-generated SHA1 digest to create a linkage between
+        # files on disk (in fcrepo.binary-store-path) and objects in the repository.
+        solr_doc['digest_ssim'] = digest_from_content
+        solr_doc['page_count_tesim']        = object.page_count
+        solr_doc['file_title_tesim']        = object.file_title
+        solr_doc['duration_tesim']          = object.duration
+        solr_doc['sample_rate_tesim']       = object.sample_rate
+        solr_doc['original_checksum_tesim'] = object.original_checksum
+        solr_doc['original_filename_ssim'] = original_file_name
+      end
+    end
+
+    private
+
+      def digest_from_content
+        return unless object.original_file
+        object.original_file.digest.first.to_s
+      end
+
+      def original_file_name
+        return unless object.original_file
+        object.original_file.id.to_s
+      end
+
+      def file_format
+        if object.mime_type.present? && object.format_label.present?
+          "#{object.mime_type.split('/').last} (#{object.format_label.join(', ')})"
+        elsif object.mime_type.present?
+          object.mime_type.split('/').last
+        elsif object.format_label.present?
+          object.format_label
+        end
+      end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,8 @@ services:
       - californica_tmp:/californica/tmp
       - tmp:/tmp
     working_dir: /californica
-
+    stdin_open: true
+    tty: true
   fedora:
     image: nulib/fcrepo4:4.7.5
     ports:


### PR DESCRIPTION
This avoids an expensive operation to get the
original file name from the `FileSet` object
by indexing that value into solr.