### PR TITLE
Fixed a bug with duplicate permissions. Jira 608

### DIFF
--- a/app/models/concerns/discoverable.rb
+++ b/app/models/concerns/discoverable.rb
@@ -81,6 +81,8 @@ module Discoverable
       prop['id'] = selected.id if selected
     end
 
+    # We also added this line in californica to remove duplicate values from the array
+    attributes_collection = attributes_collection.uniq
     clean_collection = remove_bad_deletes(attributes_collection)
 
     self.permissions_attributes_without_uniqueness = clean_collection


### PR DESCRIPTION
The bug was that when you edit a Work record in the browser and change
its visibility, and then apply the parent Work's visibility to the child
FileSet records, in some situations, the resulting visibility for the
FileSet records would be incorrect.