### PR TITLE
View logs on CSV Import status page

### DIFF
--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -29,6 +29,16 @@ class CsvImportsController < ApplicationController
     end
   end
 
+  def log
+    log_file = Rails.root.join('log', "ingest_#{params[:id]}.log")
+    log_text = if File.exist?(log_file)
+                 File.open(log_file).read
+               else
+                 'Could not read a log file for this import'
+               end
+    render plain: log_text
+  end
+
   private
 
     def load_and_authorize_preview

--- a/app/importers/actor_record_importer.rb
+++ b/app/importers/actor_record_importer.rb
@@ -25,7 +25,7 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
   end
 
   def update_for(existing_record:, update_record:)
-    info_stream << "event: record_update_started, row_id: #{@row_id}, collection_id: #{collection_id}, ark: #{existing_record.ark}"
+    info_stream << "event: record_update_started, row_id: #{@row_id}, collection_id: #{collection_id}, ark: #{existing_record.ark}\n"
 
     additional_attrs = {
       uploaded_files: create_upload_files(update_record),
@@ -46,11 +46,11 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
     terminator = Hyrax::Actors::Terminator.new
     middleware = Californica::IngestMiddlewareStack.build_stack.build(terminator)
     if middleware.update(actor_env)
-      info_stream << "event: record_updated, row_id: #{@row_id}, record_id: #{existing_record.id}, collection_id: #{collection_id}, record_title: #{attrs[:title]&.first}"
+      info_stream << "event: record_updated, row_id: #{@row_id}, record_id: #{existing_record.id}, collection_id: #{collection_id}, record_title: #{attrs[:title]&.first}\n"
       @success_count += 1
     else
       existing_record.errors.each do |attr, msg|
-        error_stream << "event: validation_failed, row_id: #{@row_id}, collection_id: #{collection_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: record_title: #{attrs[:title] ? attrs[:title] : attrs}"
+        error_stream << "event: validation_failed, row_id: #{@row_id}, collection_id: #{collection_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: record_title: #{attrs[:title] ? attrs[:title] : attrs}\n"
       end
       @failure_count += 1
     end
@@ -59,7 +59,7 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
   # Create an object using the Hyrax actor stack
   # We assume the object was created as expected if the actor stack returns true.
   def create_for(record:)
-    info_stream << "event: record_import_started, row_id: #{@row_id}, ark: #{record.ark}"
+    info_stream << "event: record_import_started, row_id: #{@row_id}, ark: #{record.ark}\n"
 
     additional_attrs = {
       uploaded_files: create_upload_files(record),
@@ -88,11 +88,11 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
     middleware = Californica::IngestMiddlewareStack.build_stack.build(terminator)
 
     if middleware.create(actor_env)
-      info_stream << "event: record_created, row_id: #{@row_id}, record_id: #{created.id}, ark: #{created.ark}"
+      info_stream << "event: record_created, row_id: #{@row_id}, record_id: #{created.id}, ark: #{created.ark}\n"
     else
       error_messages = []
       created.errors.each do |attr, msg|
-        error_stream << "event: validation_failed, row_id: #{@row_id}, attribute: #{attr.capitalize}, message: #{msg}, ark: #{attrs[:ark] ? attrs[:ark] : attrs}"
+        error_stream << "event: validation_failed, row_id: #{@row_id}, attribute: #{attr.capitalize}, message: #{msg}, ark: #{attrs[:ark] ? attrs[:ark] : attrs}\n"
         error_messages << msg
       end
       # Errors raised here should be rescued in the CsvRowImportJob and the

--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -42,11 +42,11 @@ class CalifornicaImporter
   end
 
   def ingest_log_filename
-    @ingest_log_filename ||= ENV['INGEST_LOG'] || Rails.root.join('log', "ingest_#{timestamp}.log").to_s
+    Rails.root.join('log', "ingest_#{@csv_import.id}.log").to_s
   end
 
   def error_log_filename
-    @error_log_filename ||= ENV['ERROR_LOG'] || Rails.root.join('log', "errors_#{timestamp}.log").to_s
+    Rails.root.join('log', "errors_#{@csv_import.id}.log").to_s
   end
 
   def setup_logging

--- a/app/importers/collection_record_importer.rb
+++ b/app/importers/collection_record_importer.rb
@@ -8,34 +8,34 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
   end
 
   def create_for(record:)
-    info_stream << "event: collection_import_started, batch_id: #{batch_id}, record_title: #{record.respond_to?(:title) ? record.title : record}"
+    info_stream << "event: collection_import_started, batch_id: #{batch_id}, record_title: #{record.respond_to?(:title) ? record.title : record}\n"
 
     collection = Collection.find_or_create_by_ark(record.ark)
     collection.attributes = attributes_for(record: record)
     collection.recalculate_size = false
     if collection.save(update_index: false)
-      info_stream << "event: collection_created, batch_id: #{batch_id}, record_id: #{collection.id}, record_title: #{collection.title}"
+      info_stream << "event: collection_created, batch_id: #{batch_id}, record_id: #{collection.id}, record_title: #{collection.title}\n"
       @success_count += 1
     else
       collection.errors.each do |attr, msg|
-        error_stream << "event: validation_failed, batch_id: #{batch_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: #{collection.title.first}"
+        error_stream << "event: validation_failed, batch_id: #{batch_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: #{collection.title.first}\n"
       end
       @failure_count += 1
     end
   end
 
   def update_for(existing_record:, update_record:)
-    info_stream << "event: collection_update_started, batch_id: #{batch_id}, ark: #{update_record.ark}"
+    info_stream << "event: collection_update_started, batch_id: #{batch_id}, ark: #{update_record.ark}\n"
 
     collection = existing_record
     collection.attributes = attributes_for(record: update_record)
     collection.recalculate_size = false
     if collection.save
-      info_stream << "event: collection_updated, batch_id: #{batch_id}, record_id: #{collection.id}, ark: #{collection.ark}"
+      info_stream << "event: collection_updated, batch_id: #{batch_id}, record_id: #{collection.id}, ark: #{collection.ark}\n"
       @success_count += 1
     else
       collection.errors.each do |attr, msg|
-        error_stream << "event: validation_failed, batch_id: #{batch_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: #{collection.title.first}"
+        error_stream << "event: validation_failed, batch_id: #{batch_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: #{collection.title.first}\n"
       end
       @failure_count += 1
     end

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -16,6 +16,10 @@
 
     <label> Queued records: </label>
     <span> <%= @csv_import.record_count %> </span>
+
+    <br />
+    <label> Logs: </label>
+    <span> <a href="/csv_imports/<%= @csv_import.id %>/log">Ingest Log</a> </span>
   </p>
   <table class="table-condensed table-striped datatable dataTable no-footer" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
     <thead>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   post 'csv_imports/preview', as: 'preview_csv_import'
   get 'csv_imports/preview', to: redirect('csv_imports/new')
   resources :csv_imports, only: [:index, :show, :new, :create]
+  get 'csv_imports/:id/log', to: 'csv_imports#log'
 
   get 'branding_info/:id', to: 'branding_info#show', as: 'branding_info'
 

--- a/spec/controllers/csv_imports_controller_spec.rb
+++ b/spec/controllers/csv_imports_controller_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe CsvImportsController, type: :controller do
       end
     end
 
+    describe 'GET #log' do
+      before { get :log, params: { id: csv_import.to_param } }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
     describe "POST #create" do
       it 'denies access' do
         post :create, params: { csv_import: valid_attributes }
@@ -78,6 +87,15 @@ RSpec.describe CsvImportsController, type: :controller do
 
       it 'denies access' do
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe "GET #log" do
+      before { get :log, params: { id: csv_import.to_param } }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(root_path)
       end
     end
 
@@ -133,6 +151,14 @@ RSpec.describe CsvImportsController, type: :controller do
 
     describe "GET #new" do
       before { get :new }
+
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #log" do
+      before { get :log, params: { id: csv_import.to_param } }
 
       it 'is successful' do
         expect(response).to be_successful


### PR DESCRIPTION
This adds a route to see the ingest log for
a `csv_import`. This was previously using
a timestamp on the log file, but each `csv_import`
has an ID which can be discoverd through the UI.

Using the ID in the name will make it easier to
find the log, and allows for providing the ability
to view the log in the browser.