### PR TITLE
Add sidekiq-status gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'rsolr', '>= 1.0'
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq', '~> 5.1.3'
 gem 'sidekiq-failures'
+gem 'sidekiq-status'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
     clipboard-rails (1.7.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -539,6 +541,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
+    numerizer (0.1.1)
     oauth (0.5.4)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
@@ -751,6 +754,9 @@ GEM
       redis (>= 3.3.5, < 5)
     sidekiq-failures (1.0.0)
       sidekiq (>= 4.0.0)
+    sidekiq-status (1.1.4)
+      chronic_duration
+      sidekiq (>= 3.0)
     signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -895,6 +901,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq (~> 5.1.3)
   sidekiq-failures
+  sidekiq-status
   simplecov (~> 0.16.1)
   solr_wrapper (>= 0.3)
   spring

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,10 @@
 # frozen_string_literal: true
 class ApplicationJob < ActiveJob::Base
+  include Sidekiq::Status::Worker
+
+  attr_accessor :jid
+
+  before_perform do |job|
+    job.jid = job.provider_job_id
+  end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'sidekiq'
+require 'sidekiq-status'
+
+Sidekiq.configure_client do |config|
+  # accepts :expiration (optional)
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+end
+
+Sidekiq.configure_server do |config|
+  # accepts :expiration (optional)
+  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
+
+  # accepts :expiration (optional)
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'sidekiq/web'
+require 'sidekiq-status/web'
 
 Rails.application.routes.draw do
   get 'importer_documentation/guide'


### PR DESCRIPTION
This gem will give us more details about the status
of jobs in the sidekiq interface. When this is
installed there is a Statuses tab in the UI at the
top of the screen.