### PR TITLE
Persist manifest with db

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class Manifest < ApplicationRecord
+end

--- a/db/migrate/20190618015737_create_manifests.rb
+++ b/db/migrate/20190618015737_create_manifests.rb
@@ -1,0 +1,9 @@
+class CreateManifests < ActiveRecord::Migration[5.1]
+  def change
+    create_table :manifests do |t|
+      t.text :json
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190607170700) do
+ActiveRecord::Schema.define(version: 20190618015737) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -234,6 +234,12 @@ ActiveRecord::Schema.define(version: 20190607170700) do
     t.string "message_id"
     t.index ["notification_id"], name: "index_mailboxer_receipts_on_notification_id"
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
+  end
+
+  create_table "manifests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text "json"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -600,10 +606,7 @@ ActiveRecord::Schema.define(version: 20190607170700) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
-  add_foreign_key "collection_type_participants", "hyrax_collection_types"
   add_foreign_key "csv_imports", "users"
-  add_foreign_key "curation_concerns_operations", "users"
-  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
   add_foreign_key "permission_template_accesses", "permission_templates"

--- a/spec/factories/manifests.rb
+++ b/spec/factories/manifests.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :manifest do
+    json { "MyText" }
+  end
+end

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Manifest, type: :model do
+  let(:manifest) { described_class.new }
+  let(:json) { '{ something: \'somewhere\'}' }
+  describe 'storing some json' do
+    it 'has a text field that can be used for storing the manifest' do
+      manifest.json = json
+      manifest.save
+      expect(manifest.json).to eq(json)
+    end
+  end
+end


### PR DESCRIPTION
This caches the manifest in the db
instead of redis. This will allow
the manifests to be cached on disk
instead of just in-memory.