### PR TITLE
Fix for translation missing errors

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -49,7 +49,7 @@ en:
   simple_form:
     hints:
       defaults:
-        based_near: A hyrax default field that we're not using. Use Location instead.
+        based_near: A hyrax default field that we are not using. Use Location instead.
     labels:
       defaults:
         based_near: Based Near

--- a/spec/system/locales.rb
+++ b/spec/system/locales.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'locales changing the labels in forms', :clean, type: :system, js: true do
+  context 'logged in as an admin user' do
+    let(:admin) { FactoryBot.create :admin }
+    before { login_as admin }
+
+    scenario 'visiting the works list' do
+      visit '/dashboard/my/works'
+      expect(page).to have_content('Visibility')
+      expect(page).not_to have_content('translation missing')
+    end
+  end
+end


### PR DESCRIPTION
There was an error in the yaml locale file
that was causing translation missing errors
in the admin interface. This removes the bad
char and checks that the admin interface isn't
saying 'translation missing'