### PR TITLE
Use a separate key for caching manifests

### DIFF
--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -36,8 +36,8 @@ module Hyrax
         date_modified = @solr_doc[:date_modified_dtsi] || @solr_doc[:system_create_dtsi]
         key = date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + @solr_doc[:id]
 
-        if Manifest.exists?(key)
-          render json: Manifest.find(key).json
+        if Manifest.exists?(cache_manifest_key: key)
+          render json: Manifest.find_by(cache_manifest_key: key).json
         else
           curation_concern = _curation_concern_type.find(params[:id]) unless curation_concern
           builder_service = Californica::ManifestBuilderService.new(curation_concern: curation_concern)
@@ -51,7 +51,7 @@ module Hyrax
       end
 
       def persist_manifest(key:, json:)
-        manifest = Manifest.new(id: key, json: json)
+        manifest = Manifest.new(cache_manifest_key: key, json: json)
         manifest.save
       end
   end

--- a/db/migrate/20190618174001_add_cache_manifest_key_to_manifests.rb
+++ b/db/migrate/20190618174001_add_cache_manifest_key_to_manifests.rb
@@ -1,0 +1,5 @@
+class AddCacheManifestKeyToManifests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :manifests, :cache_manifest_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190618015737) do
+ActiveRecord::Schema.define(version: 20190618174001) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -240,6 +240,7 @@ ActiveRecord::Schema.define(version: 20190618015737) do
     t.text "json"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "cache_manifest_key"
   end
 
   create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -4,11 +4,30 @@ require 'rails_helper'
 RSpec.describe Manifest, type: :model do
   let(:manifest) { described_class.new }
   let(:json) { '{ something: \'somewhere\'}' }
+  let(:cache_manifest_key) { '2019-something' }
   describe 'storing some json' do
     it 'has a text field that can be used for storing the manifest' do
       manifest.json = json
       manifest.save
       expect(manifest.json).to eq(json)
+    end
+
+    it 'has a string that can be used for storing a key for caching' do
+      manifest.cache_manifest_key = cache_manifest_key
+      manifest.save
+      expect(manifest.cache_manifest_key).to eq(cache_manifest_key)
+    end
+
+    it 'can determine if a manifest exists based on the cache key' do
+      manifest.cache_manifest_key = cache_manifest_key
+      manifest.save
+      expect(Manifest.exists?(cache_manifest_key: cache_manifest_key)).to eq true
+    end
+
+    it 'can find a record based on the cache key' do
+      manifest.cache_manifest_key = cache_manifest_key
+      manifest.save
+      expect(Manifest.find_by(cache_manifest_key: cache_manifest_key)).to be_a Manifest
     end
   end
 end


### PR DESCRIPTION
Don't use the primary key for storing the
key used to cache the manifests in the db.