### PR TITLE
Use Cantaloupe url for id in manifest

### DIFF
--- a/app/views/manifest.json.jbuilder
+++ b/app/views/manifest.json.jbuilder
@@ -41,7 +41,8 @@ json.sequences [''] do
         json.height 480
         json.service do
           json.set! :@context, 'http://iiif.io/api/image/2/context.json'
-          json.set! :@id, "#{request.base_url}/images/#{CGI.escape(original_file.id)}"
+          # The base url for the info.json file
+          json.set! :@id, "#{ENV['IIIF_SERVER_URL']}#{CGI.escape(original_file.id)}"
           json.profile 'http://iiif.io/api/image/2/level2.json'
         end
       end

--- a/db/migrate/20190618201710_change_manifest_json_to_text.rb
+++ b/db/migrate/20190618201710_change_manifest_json_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeManifestJsonToText < ActiveRecord::Migration[5.1]
+  def change
+    change_column(:manifests, :json, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190618174001) do
+ActiveRecord::Schema.define(version: 20190618201710) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false


### PR DESCRIPTION
This also changes the Manifest model json
column to text instead of string. In MySQL,
string column types aren't large enough to
store the manifests.