### PR TITLE
disable parallel import of CSVRows

### DIFF
--- a/app/importers/record_importer.rb
+++ b/app/importers/record_importer.rb
@@ -19,7 +19,7 @@ class RecordImporter < Darlingtonia::HyraxRecordImporter
       row_number: record.mapper.row_number,
       csv_import_id: batch_id
     )
-    CsvRowImportJob.perform_later(row_id: csv_row.id)
+    CsvRowImportJob.perform_now(row_id: csv_row.id)
   end
 
   def success_count


### PR DESCRIPTION
Since parallel execution of CsvRowImportJob is currently not working, this executes it inline while we decide what to do.