### PR TITLE
More complete example in manifest view spec

### DIFF
--- a/spec/views/manifest.json.jbuilder_spec.rb
+++ b/spec/views/manifest.json.jbuilder_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "rails_helper"
+require 'cgi'
 
 RSpec.describe "manifest", type: :view do
   let(:work) { FactoryBot.create(:work) }
@@ -8,22 +9,61 @@ RSpec.describe "manifest", type: :view do
   let(:sets) { Californica::ManifestBuilderService.new(curation_concern: work).sets }
   let(:manifest) { File.open(Rails.root.join('spec', 'fixtures', 'manifests', 'manifest.json')) }
 
-  it "displays a valid IIIF Presentation API manifest" do
+  before do
+    Hydra::Works::UploadFileToFileSet.call(file_set, File.open(Rails.root.join('spec', 'fixtures', 'images', 'good', 'food.tif')))
+    work.ordered_members << file_set
+    work.save
     assign(:root_url, 'http://localhost:3000/manifest')
     assign(:solr_doc, solr_doc)
     assign(:sets, sets)
+  end
 
-    Hydra::Works::UploadFileToFileSet.call(file_set, File.open(Rails.root.join('spec', 'fixtures', 'images', 'good', 'food.tif')))
-    work.ordered_members << file_set
+  it "displays a valid IIIF Presentation API manifest" do
     render
-    json = JSON.parse(rendered)
-
-    expect(json['label']).to eq work.title.first
-    expect(json['description']).to eq work.description.first
-    expect(json["@context"]).to eq "http://iiif.io/api/presentation/2/context.json"
-    expect(json["@id"]).to eq "http://localhost:3000/manifest"
-    expect(json["@type"]).to eq "sc:Manifest"
-    expect(json["sequences"][0]["@type"]).to eq "sc:Sequence"
-    expect(json["sequences"][0]["canvases"]).not_to be nil
+    file_id = CGI.escape(work.file_sets.first.original_file.id)
+    doc = <<~HEREDOC
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "http://localhost:3000/manifest",
+  "label": "#{work.title.first}",
+  "description": "#{work.description.first}",
+  "sequences": [
+    {
+      "@type": "sc:Sequence",
+      "@id": "http://localhost:3000/manifest/sequence/normal",
+      "canvases": [
+        {
+          "@id": "http://localhost:3000/manifest/canvas/#{work.file_sets.first.id}",
+          "@type": "sc:Canvas",
+          "label": null,
+          "description": null,
+          "width": 640,
+          "height": 480,
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@type": "dctypes:Image",
+                "@id": "http://test.host/images/#{file_id}/full/600,/0/default.jpg",
+                "width": 640,
+                "height": 480,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "http://test.host/images/#{file_id}",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }
+              },
+              "on": "http://test.host/concern/works/#{work.id}/manifest/canvas/#{work.file_sets.first.id}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+HEREDOC
+    expect(JSON.parse(rendered)).to eq(JSON.parse(doc))
   end
 end


### PR DESCRIPTION
This provides a more complete example in the
view spec for the IIIF Manifest. Instead
of checking for indvidual properties it compares
everything from a template at one time.