### PR TITLE
Additional spec for ChildWork manifest view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,7 @@ RSpec/ExampleLength:
   Enabled: true
   Exclude:
     - 'spec/system**/*'
+    - 'spec/views**/*'
     - 'spec/tasks/ingest_spec.rb'
     - 'spec/importers/californica_mapper_spec.rb'
     - 'spec/importers/californica_importer_spec.rb'
@@ -99,7 +100,7 @@ RSpec/ExampleLength:
     - spec/jobs/mss_csv_import_job_spec.rb
     - spec/views/manifest.json.jbuilder_spec.rb
     - 'spec/jobs/inherit_permissions_job_spec.rb'
-
+    
 RSpec/LetSetup:
   Enabled: false
 

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -2,6 +2,25 @@
 # See https://github.com/ffaker/ffaker for more fake data
 FactoryBot.define do
   factory :work do
+    transient do
+      tif { nil }
+      child_work { nil }
+    end
+
+    after(:build) do |work, evaluator|
+      if evaluator.tif
+        file_set = FactoryBot.create(:file_set)
+        Hydra::Works::UploadFileToFileSet.call(file_set, evaluator.tif)
+        work.ordered_members << file_set
+        work.save
+      end
+
+      if evaluator.child_work
+        work.ordered_members << evaluator.child_work
+        work.save
+      end
+    end
+
     id { Noid::Rails::Service.new.mint }
     ark { "ark:/13030/#{Noid::Rails::Service.new.mint}" }
     title { [] << FFaker::Book.title }

--- a/spec/views/manifest.json.jbuilder_with_child_spec.rb
+++ b/spec/views/manifest.json.jbuilder_with_child_spec.rb
@@ -4,7 +4,8 @@ require 'cgi'
 
 RSpec.describe "manifest", type: :view do
   let(:tif) { File.open(Rails.root.join('spec', 'fixtures', 'images', 'good', 'food.tif')) }
-  let(:work) { FactoryBot.create(:work, tif: tif) }
+  let(:work) { FactoryBot.create(:work, child_work: child_work) }
+  let(:child_work) { FactoryBot.create(:work, tif: tif) }
   let(:solr_doc) { SolrDocument.find(work.id) }
   let(:sets) { Californica::ManifestBuilderService.new(curation_concern: work).sets }
 
@@ -14,9 +15,9 @@ RSpec.describe "manifest", type: :view do
     assign(:sets, sets)
   end
 
-  it "displays a valid IIIF Presentation API manifest" do
+  it "displays manifest for a work with child works" do
     render
-    file_id = CGI.escape(work.file_sets.first.original_file.id)
+    file_id = CGI.escape(work.ordered_members.to_a.first.file_sets.first.original_file.id)
     doc = <<~HEREDOC
 {
   "@context": "http://iiif.io/api/presentation/2/context.json",
@@ -30,10 +31,10 @@ RSpec.describe "manifest", type: :view do
       "@id": "http://localhost:3000/manifest/sequence/normal",
       "canvases": [
         {
-          "@id": "http://localhost:3000/manifest/canvas/#{work.file_sets.first.id}",
+          "@id": "http://localhost:3000/manifest/canvas/#{work.ordered_members.to_a.first.id}",
           "@type": "sc:Canvas",
-          "label": null,
-          "description": null,
+          "label": "#{work.ordered_members.to_a.first.title.first}",
+          "description": "#{work.ordered_members.to_a.first.description.first}",
           "width": 640,
           "height": 480,
           "images": [
@@ -51,7 +52,7 @@ RSpec.describe "manifest", type: :view do
                   "profile": "http://iiif.io/api/image/2/level2.json"
                 }
               },
-              "on": "http://test.host/concern/works/#{work.id}/manifest/canvas/#{work.file_sets.first.id}"
+              "on": "http://test.host/concern/works/#{work.id}/manifest/canvas/#{work.ordered_members.to_a.first.id}"
             }
           ]
         }


### PR DESCRIPTION
There is a view spec for a work with a file attached.
This adds another spec that describes a manifest for
a work with ChildWorks.

This also adds some transient properties in the
Work factory to allow works with files or ChildWorks to
be easily created.