### PR TITLE
rake tasks to audit records based on CSV

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,6 +137,10 @@ Style/BracesAroundHashParameters:
   Exclude:
     - 'spec/importers/californica_mapper_spec.rb'
 
+# Controlling flow w/ guard clauses can be overly clever and makes code harder to read - ABW
+Style/GuardClause:
+  Enabled: false
+
 Style/Next:
   Exclude:
     - 'app/uploaders/csv_manifest_validator.rb'

--- a/app/auditors/californica_csv_auditor.rb
+++ b/app/auditors/californica_csv_auditor.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class CalifornicaCsvAuditor < Darlingtonia::CsvParser
+  attr_accessor :error_stream, :info_stream, :row_auditors
+
+  def initialize(file:,
+                 error_stream: Darlingtonia.config.default_error_stream,
+                 info_stream:  Darlingtonia.config.default_info_stream,
+                 **opts)
+    self.error_stream = error_stream
+    self.info_stream  = info_stream
+
+    self.row_auditors = [
+      FileCountAuditor.new(error_stream: error_stream, info_stream: info_stream)
+    ]
+
+    super
+  end
+
+  def audit
+    # Use the CalifornicaMapper to extract an ark.
+    # Match on ark. For every ark in the file, find the corresponding object
+    # and audit it.
+    CSV.parse(file.read, headers: true).each_with_index do |row, index|
+      row_number = index + 2 # +1 to escape 0-based-indexing, +1 for skipped header row
+
+      item = Darlingtonia::InputRecord.from(metadata: row, mapper: CalifornicaMapper.new)
+      ark = item.mapper.metadata["Item ARK"]
+      next unless ark
+      ark = Ark.ensure_prefix(ark)
+
+      records = ActiveFedora::Base.where(ark_ssi: ark)
+
+      error_stream << "Row #{row_number}: Found #{records.length} matches for ark #{ark}" if records.length != 1
+
+      records.each do |record|
+        row_auditors.each do |row_auditor|
+          row_auditor.audit(record, row)
+        end
+      end
+    end
+
+    # info_stream << "Actually processed #{actual_records_processed} records"
+  rescue CSV::MalformedCSVError
+    # error reporting for this case is handled by validation
+    []
+  end
+end

--- a/app/auditors/file_count_auditor.rb
+++ b/app/auditors/file_count_auditor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class FileCountAuditor
+  attr_accessor :error_stream, :info_stream
+
+  def initialize(error_stream: Darlingtonia.config.default_error_stream,
+                 info_stream:  Darlingtonia.config.default_info_stream)
+    self.error_stream = error_stream
+    self.info_stream  = info_stream
+  end
+
+  def audit(stored_record, csv_row)
+    info_stream << "auditing #{stored_record.ark}"
+    n_expected = csv_row["File Name"].to_s.split('|~|').count
+    n_stored = stored_record.respond_to?(:file_sets) ? stored_record.file_sets.count : 0
+
+    error_stream << "#{stored_record.ark} id=#{stored_record.id}: expected #{n_expected} files, found #{n_stored}" if n_stored != n_expected
+  end
+end

--- a/lib/tasks/audit.rake
+++ b/lib/tasks/audit.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+namespace :californica do
+  desc 'Audit records listed in csv.'
+  task audit: [:environment] do
+    unless CSV_FILE
+      puts "Specify import parameters like this: CSV_FILE=/path/to/file.csv bundle exec rails californica:audit"
+      next
+    end
+    puts "Auditing works listed in #{CSV_FILE}"
+    file = File.open(CSV_FILE)
+    CalifornicaCsvAuditor.new(file: file, error_stream: $stdout, info_stream: $stdout).audit
+    file.close
+  end
+end

--- a/spec/auditors/californica_csv_auditor_spec.rb
+++ b/spec/auditors/californica_csv_auditor_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CalifornicaCsvAuditor, :clean do
+  subject(:auditor) { described_class.new(file: file, error_stream: []) }
+  let(:file)        { File.open(csv_path) }
+  let(:csv_path)    { 'spec/fixtures/example.csv' }
+  let(:record)      { FactoryBot.create(:work, id: 'w4qn2000zz-89112', ark: 'ark:/21198/zz0002nq4w') }
+  let(:record2)     { FactoryBot.create(:work, id: 'abcxyz', ark: 'ark:/21198/zz0002nq4w') }
+  let(:import_path) { File.join(fixture_path, 'clusc_1_1_00010432a.tif') }
+  let(:file_set_1)  { FactoryBot.create(:file_set, import_url: import_path) }
+  let(:file_set_2)  { FactoryBot.create(:file_set, import_url: import_path) }
+
+  context 'when there are too many FileSets' do
+    before do
+      record.ordered_members << file_set_1
+      record.ordered_members << file_set_2
+    end
+
+    it 'logs an error' do
+      auditor.audit
+      expect(auditor.error_stream).to contain_exactly("ark:/21198/zz0002nq4w id=w4qn2000zz-89112: expected 1 files, found 2")
+    end
+  end
+
+  context 'when there are too few FileSets' do
+    before do
+      record
+    end
+
+    it 'logs an error' do
+      auditor.audit
+      expect(auditor.error_stream).to contain_exactly("ark:/21198/zz0002nq4w id=w4qn2000zz-89112: expected 1 files, found 0")
+    end
+  end
+
+  context 'when there are just enough FileSets' do
+    before do
+      record.ordered_members << file_set_1
+    end
+
+    it 'doesn\'t log any errors' do
+      auditor.audit
+      expect(auditor.error_stream).to eq []
+    end
+  end
+
+  context 'when there are too few records' do
+    # before do
+    #   record.ordered_members << file_set_1
+    # end
+
+    it 'logs an error' do
+      auditor.audit
+      expect(auditor.error_stream).to contain_exactly('Row 2: Found 0 matches for ark ark:/21198/zz0002nq4w')
+    end
+  end
+
+  context 'when there are too many records' do
+    before do
+      record.ordered_members << file_set_1
+      record2.ordered_members << file_set_1
+    end
+
+    it 'logs an error' do
+      auditor.audit
+      expect(auditor.error_stream).to contain_exactly('Row 2: Found 2 matches for ark ark:/21198/zz0002nq4w')
+    end
+  end
+end


### PR DESCRIPTION
Initially, the audit checks that each line of the CSV corresponds to a single record, and that record has a number of FileSets equal to the number of files in the "File Name" column of the CSV.