### PR TITLE
rescue errors in imports

### DIFF
--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -55,11 +55,15 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
   def order_child_works
     works_arks = @works_needing_ordering.reject(&:blank?)
     works_arks.each do |work_ark|
-      page_orderings = PageOrder.where(parent: Ark.ensure_prefix(work_ark))
-      ordered_arks = page_orderings.sort_by(&:sequence)
-      work = Work.find_by_ark(Ark.ensure_prefix(work_ark))
-      work.ordered_members = ordered_arks.map { |b| ChildWork.find_by_ark(b.child) }
-      work.save
+      begin
+        page_orderings = PageOrder.where(parent: Ark.ensure_prefix(work_ark))
+        ordered_arks = page_orderings.sort_by(&:sequence)
+        work = Work.find_by_ark(Ark.ensure_prefix(work_ark))
+        work.ordered_members = ordered_arks.map { |b| ChildWork.find_by_ark(b.child) }
+        work.save
+      rescue e
+        error_stream << "#{work_ark}: #{e.message}"
+      end
     end
   end
 

--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -27,6 +27,8 @@ class CalifornicaImporter
     Darlingtonia::Importer.new(parser: parser, record_importer: record_importer, info_stream: @info_stream, error_stream: @error_stream).import
     parser.order_child_works
     parser.reindex_collections
+  rescue => e
+    @error_stream << "CsvImportJob failed: #{e.message}"
   end
 
   def parser

--- a/app/jobs/start_csv_import_job.rb
+++ b/app/jobs/start_csv_import_job.rb
@@ -9,5 +9,7 @@ class StartCsvImportJob < ApplicationJob
     log_stream << "Starting import with batch ID: #{csv_import_id}"
     importer = CalifornicaImporter.new(csv_import)
     importer.import
+  rescue => e
+    log_stream << "CsvImportJob failed: #{e.message}"
   end
 end


### PR DESCRIPTION
Errors have been causing imports to fail and restart, ingesting multiple copies of many filesets. Rescuing and logging these errors should help.