### PR TITLE
Require full path for "File Name"

### DIFF
--- a/app/assets/markdown/importer_guide.md
+++ b/app/assets/markdown/importer_guide.md
@@ -1,65 +1,72 @@
 # <a href="#required-fields">Required Fields</a>
-* [File Name](#file-name)
-* [Item ARK](#item-ark)
-* [Object Type](#object-type)
-* [Parent ARK](#parent-ark) (required for `Work` objects)
-* [Rights.copyrightStatus](#rights.copyrightstatus)
-* [Title](#title)
+
+- [File Name](#file-name)
+- [Item ARK](#item-ark)
+- [Object Type](#object-type)
+- [Parent ARK](#parent-ark) (required for `Work` objects)
+- [Rights.copyrightStatus](#rights.copyrightstatus)
+- [Title](#title)
 
 # <a href="#other-allowed-fields">Other Allowed Fields</a>
-* [AltIdentifier.local](#altidentifier.local)
-* [AltTitle.other](#alttitle.other)
-* [AltTitle.uniform](#alttitle.uniform)
-* [Coverage.geographic](#coverage.geographic)
-* [Date.creation](#date.creation)
-* [Date.normalized](#date.normalized)
-* [Description.caption](#description.caption)
-* [Description.fundingNote](#description.fundingnote)
-* [Description.latitude](#description.latitude)
-* [Description.longitude](#description.longitude)
-* [Description.note](#description.note)
-* [Format.dimensions](#format.dimensions)
-* [Format.extent](#format.extent)
-* [Format.medium](#format.medium)
-* [Item Sequence](#item-sequence)
-* [Language](#language)
-* [Name.architect](#name.architect)
-* [Name.photographer](#name.photographer)
-* [Name.repository](#name.repository)
-* [Name.subject](#name.subject)
-* [Project Name](#project-name)
-* [Place of origin](#place-of-origin)
-* [Publisher.publisherName](#publisher.publishername)
-* [Relation.isPartOf](#relation.ispartof)
-* [Rights.countryCreation](#rights.countrycreation)
-* [Rights.rightsHolderContact](#rights.rightsholdercontact)
-* [Subject](#subject)
-* [Support](#support)
-* [Type.genre](#type.genre)
-* [Type.typeOfResource](#type.typeofresource)
-* [Visibility](#visibility)
+
+- [AltIdentifier.local](#altidentifier.local)
+- [AltTitle.other](#alttitle.other)
+- [AltTitle.uniform](#alttitle.uniform)
+- [Coverage.geographic](#coverage.geographic)
+- [Date.creation](#date.creation)
+- [Date.normalized](#date.normalized)
+- [Description.caption](#description.caption)
+- [Description.fundingNote](#description.fundingnote)
+- [Description.latitude](#description.latitude)
+- [Description.longitude](#description.longitude)
+- [Description.note](#description.note)
+- [Format.dimensions](#format.dimensions)
+- [Format.extent](#format.extent)
+- [Format.medium](#format.medium)
+- [Item Sequence](#item-sequence)
+- [Language](#language)
+- [Name.architect](#name.architect)
+- [Name.photographer](#name.photographer)
+- [Name.repository](#name.repository)
+- [Name.subject](#name.subject)
+- [Project Name](#project-name)
+- [Place of origin](#place-of-origin)
+- [Publisher.publisherName](#publisher.publishername)
+- [Relation.isPartOf](#relation.ispartof)
+- [Rights.countryCreation](#rights.countrycreation)
+- [Rights.rightsHolderContact](#rights.rightsholdercontact)
+- [Subject](#subject)
+- [Support](#support)
+- [Type.genre](#type.genre)
+- [Type.typeOfResource](#type.typeofresource)
+- [Visibility](#visibility)
 
 ## Required Fields
 
 ### File Name (required)
-A filename to attach to the object. Can be multivalued.
 
-This field is a string.  **This field is required**.
+A _full file path_ to the file in the "Masters" netapp volume. Currently this must be single-valued. If a Work has multiple files associated with it, then each file should be given its own line with object type of "ChildWork" and a "Parent ARK" value that refers to the original.
+
+If the File Name starts with "Masters/", it will be used as is. Otherwise, it will be prepended with "Masters/dlmasters/", in order to match the content of DLCS exports.
+
+This field is a string. **This field is required**.
 
 Examples:
 
-* `clusc_1_1_00010432a.tif` (single value)
-* `clusc_1_1_00010432a.tif|~|clusc_1_1_00010432b.tif` (multivalued)
+- `Masters/dlmasters/postcards/masters/21198-zz00090ntn-1-master.tif`
+- `postcards/masters/21198-zz00090nn2-1-master.tif`
+  <br> (Imported as `Masters/dlmasters/postcards/masters/21198-zz00090nn2-1-master.tif`)
+- `Masters/DLTempSecure/ABC/xyz/file_123.tif`
 
 ### Item ARK (required)
 
 A persistent unique identifier associated with a work. It takes the form `ark:/shoulder/blade` where `shoulder` is an institutional identifier, and `blade` is a work identifier. Every work and collection in Californica must have an ark value. The ark is not multivalued -- each work can only have one.
 
-This field is a string.  **This field is required**.
+This field is a string. **This field is required**.
 
 Examples:
 
-* `ark:/21198/zz002h2fpt` (single value)
+- `ark:/21198/zz002h2fpt` (single value)
 
 ### Object Type (required)
 
@@ -67,93 +74,123 @@ A controlled vocabulary term referring to the type of repository object that wil
 
 Currently, `Manuscript` is also accepted as a synonym of `Work` and `Page` as a synonym of `ChildWork`, but this functionality may be removed at some point in the future.
 
-This field is a string.  **This field is required**.
+This field is a string. **This field is required**.
 
 Examples:
 
-* `Work` (single value)
+- `Work` (single value)
 
 ### Parent ARK (required)
 
 The ark value of this object's hierarchical parent. For a single-image `Work` object, this will be the ark of a `Collection` object. When we start importing multi-page objects, this will become more complex.
 
-This field is a string.  **This field is required for Work objects**.
+This field is a string. **This field is required for Work objects**.
 
 Examples:
 
-* `ark:/21198/zz002h2fpt` (single value)
+- `ark:/21198/zz002h2fpt` (single value)
 
 ### Rights.copyrightStatus (required)
 
 The copyright status of this work. The only currently allowed value is `copyrighted`.
 
-This field is a string.  **This field is required**.
+This field is a string. **This field is required**.
 
 Examples:
 
-* `copyrighted` (single value)
+- `copyrighted` (single value)
 
 ### Title (required)
 
 A name to aid in identifying a work.
 
-This field is a string.  **This field is required**.
+This field is a string. **This field is required**.
 
 Examples:
 
-* `[Fannie Lou Hamer, Mississippi Freedom Democratic Party delegate, at the Democratic National Convention, Atlantic City, New Jersey, August 1964] / [WKL].` (single value)
-* `[Fannie Lou Hamer, Mississippi Freedom Democratic Party delegate, at the Democratic National Convention, Atlantic City, New Jersey, August 1964] / [WKL].|~|Fannie Lou Hamer Portrait` (multivalued)
+- `[Fannie Lou Hamer, Mississippi Freedom Democratic Party delegate, at the Democratic National Convention, Atlantic City, New Jersey, August 1964] / [WKL].` (single value)
+- `[Fannie Lou Hamer, Mississippi Freedom Democratic Party delegate, at the Democratic National Convention, Atlantic City, New Jersey, August 1964] / [WKL].|~|Fannie Lou Hamer Portrait` (multivalued)
 
 ## Other Allowed Fields
 
 ### AltIdentifier.local
+
 A local identifier. Can be multivalued.
 
 Examples:
 
-* `uclamss_686_b6_f24_18` (single value)
-* `uclamss_686_b6_f24_18|~|uclamss_abc1234` (multivalued)
+- `uclamss_686_b6_f24_18` (single value)
+- `uclamss_686_b6_f24_18|~|uclamss_abc1234` (multivalued)
 
 ### AltTitle.other
+
 accepts AltTitle.translated
+
 ### AltTitle.uniform
+
 ### Coverage.geographic
+
 ### Date.creation
+
 ### Date.normalized
+
 ### Description.caption
+
 ### Description.fundingNote
+
 ### Description.latitude
+
 ### Description.longitude
+
 ### Description.note
+
 ### Format.dimensions
+
 ### Format.extent
+
 ### Format.medium
+
 ### Item Sequence
+
 ### Language
+
 ### Name.architect
+
 ### Name.photographer
+
 ### Name.repository
+
 ### Name.subject
+
 ### Place of origin
+
 ### Project Name
+
 ### Publisher.publisherName
+
 ### Relation.isPartOf
+
 ### Rights.countryCreation
+
 ### Rights.rightsHolderContact
+
 ### Subject
+
 ### Support
+
 ### Type.genre
+
 ### Type.typeOfResource
 
 ### Visibility
 
 A single-value field that must contain one of the allowed values.
 
-This field is not required.  If you omit this column or leave the value blank, it will default to `private` visibility (to avoid accidentally exposing records that should be restricted).
+This field is not required. If you omit this column or leave the value blank, it will default to `private` visibility (to avoid accidentally exposing records that should be restricted).
 
 Examples:
 
-* `public` - All users can view the record
-* `authenticated` - Logged in users can view the record
-* `discovery` - All users can view the metadata, but not the files
-* `private` - Only admin users or users who have been granted special permission may view the record
+- `public` - All users can view the record
+- `authenticated` - Logged in users can view the record
+- `discovery` - All users can view the metadata, but not the files
+- `private` - Only admin users or users who have been granted special permission may view the record

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -47,7 +47,7 @@ class CsvImportsController < ApplicationController
     end
 
     def create_params
-      params.fetch(:csv_import, {}).permit(:manifest, :import_file_path, :manifest_records)
+      params.fetch(:csv_import, {}).permit(:manifest, :manifest_records)
     end
 
     # Since we are re-rendering the form (once for
@@ -58,7 +58,6 @@ class CsvImportsController < ApplicationController
     def preserve_cache
       return unless params['csv_import']
       @csv_import.manifest_cache = params['csv_import']['manifest_cache']
-      @csv_import.import_file_path = params['csv_import']['import_file_path']
       @csv_import.record_count = params['csv_import']['record_count']
     end
 end

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -191,7 +191,13 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   end
 
   def master_file_path
-    map_field(:master_file_path).first
+    path = map_field(:master_file_path).first.to_s.strip.sub(/^\//, '')
+    return nil if path.empty?
+    if path.start_with?('Masters/')
+      path
+    else
+      'Masters/dlmasters/' + path
+    end
   end
 
   def resource_type

--- a/app/views/csv_imports/_form.html.erb
+++ b/app/views/csv_imports/_form.html.erb
@@ -40,17 +40,6 @@
         </div>
         <div class="col-md-4">
           <div class="well well-lg">
-            <p> <b>Type a directory path</b> where your binary attachments can be found.<br/>
-              It should look something like this: <b>/opt/data/Masters/dlmasters/bennett/masters</b>.
-              <br/>Note that only directories inside <b>/opt/data</b> will work.
-             </p>
-            <div class="text-center">
-              <%= render "import_file_path", form: form  %>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-4">
-          <div class="well well-lg">
             <p> <b>Preview your import</b> before starting the process. </p>
             <div class="text-center">
               <%= render "actions", form: form %>

--- a/app/views/csv_imports/_import_file_path.html.erb
+++ b/app/views/csv_imports/_import_file_path.html.erb
@@ -1,2 +1,0 @@
-<%= form.text_field :import_file_path, required: true, id: 'import-file-path', class: "import-file-path form-control" %>
-<div id="import-file-path"></div>

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -178,6 +178,32 @@ RSpec.describe CalifornicaMapper do
     end
   end
 
+  describe '#master_file_path' do
+    context 'when the path starts with a \'/\'' do
+      let(:metadata) { { 'File Name' => '/Masters/dlmasters/abc/xyz.tif' } }
+
+      it 'gets removed' do
+        expect(mapper.master_file_path).to eq 'Masters/dlmasters/abc/xyz.tif'
+      end
+    end
+
+    context 'when the path starts with \'Masters/\'' do
+      let(:metadata) { { 'File Name' => 'Masters/dlmasters/abc/xyz.tif' } }
+
+      it 'imports as is' do
+        expect(mapper.master_file_path).to eq 'Masters/dlmasters/abc/xyz.tif'
+      end
+    end
+
+    context 'when the path doesn\'t start with \'Masters\'' do
+      let(:metadata) { { 'File Name' => 'abc/xyz.tif' } }
+
+      it 'prepends \'Masters/dlmasters\'' do
+        expect(mapper.master_file_path).to eq 'Masters/dlmasters/abc/xyz.tif'
+      end
+    end
+  end
+
   describe '#repository' do
     context 'when collection is LADNN' do
       let(:metadata) do

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
       # Fill in and submit the form
       attach_file('csv_import[manifest]', csv_file, make_visible: true)
       expect(page).to have_content("You sucessfully uploaded this CSV: all_fields.csv")
-      fill_in('import-file-path', with: import_file_path)
 
       click_on 'Preview Import'
 
@@ -35,7 +34,6 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
 
       expect(page).to have_content("CSV Import #{csv_import.id}")
 
-      expect(csv_import.import_file_path).to eq import_file_path
       expect(csv_import.record_count).to eq 2
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
     end

--- a/spec/system/import_mss_from_csv_spec.rb
+++ b/spec/system/import_mss_from_csv_spec.rb
@@ -4,7 +4,6 @@ include Warden::Test::Helpers
 
 RSpec.describe 'Importing a multi-page mss from a CSV file', :clean, type: :system, js: true do
   let(:csv_file) { File.join(fixture_path, 'csv_import', 'multipage_mss', 'mss_sample.csv') }
-  let(:import_file_path) { File.join(fixture_path, 'images', 'ethiopian_mss').to_s }
 
   context 'logged in as an admin user' do
     let(:admin_user) { FactoryBot.create(:admin) }
@@ -19,7 +18,6 @@ RSpec.describe 'Importing a multi-page mss from a CSV file', :clean, type: :syst
       # Fill in and submit the form
       attach_file('csv_import[manifest]', csv_file, make_visible: true)
       expect(page).to have_content("You sucessfully uploaded this CSV: mss_sample.csv")
-      fill_in('import-file-path', with: import_file_path)
 
       click_on 'Preview Import'
 
@@ -34,7 +32,6 @@ RSpec.describe 'Importing a multi-page mss from a CSV file', :clean, type: :syst
       csv_import = CsvImport.last
 
       expect(page).to have_content("CSV Import #{csv_import.id}")
-      expect(csv_import.import_file_path).to eq import_file_path
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
     end
   end


### PR DESCRIPTION
The full path will be stored relative to the "Masters" directory at /opt/data/Masters. In production, this is mounted from the netapp.

If the input file name starts with "Masters/", it will be used as is. Otherwise, it will be prepended with "Masters/dlmasters/", in order to match the content of DLCS exports.