### PR TITLE
Streamline ingest logging

### DIFF
--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -2,16 +2,17 @@
 
 # Import CSV files according to UCLA ingest rules
 class CalifornicaImporter
-  attr_reader :error_log, :ingest_log, :depositor_id, :import_file_path
+  attr_reader :error_stream, :info_stream, :depositor_id, :import_file_path
 
   # @param [CsvImport] csv_import
-  def initialize(csv_import)
+  def initialize(csv_import, error_stream: Darlingtonia.config.default_error_stream, info_stream: Darlingtonia.config.default_info_stream)
+    @info_stream = info_stream
+    @error_stream = error_stream
     @csv_import = csv_import
     @csv_file = csv_import.manifest.to_s
     @import_file_path = csv_import.import_file_path
     @depositor_id = csv_import.user_id
     raise "Cannot find expected input file #{@csv_file}" unless File.exist?(@csv_file)
-    setup_logging
   end
 
   def import
@@ -41,20 +42,5 @@ class CalifornicaImporter
 
   def timestamp
     @timestamp ||= Time.zone.now.strftime('%Y-%m-%d-%H-%M-%S')
-  end
-
-  def ingest_log_filename
-    Rails.root.join('log', "ingest_#{@csv_import.id}.log").to_s
-  end
-
-  def error_log_filename
-    Rails.root.join('log', "errors_#{@csv_import.id}.log").to_s
-  end
-
-  def setup_logging
-    @ingest_log   = Logger.new(ingest_log_filename)
-    @error_log    = Logger.new(error_log_filename)
-    @info_stream  = CalifornicaLogStream.new(logger: @ingest_log, severity: Logger::INFO)
-    @error_stream = CalifornicaLogStream.new(logger: @error_log,  severity: Logger::ERROR)
   end
 end

--- a/app/importers/record_importer.rb
+++ b/app/importers/record_importer.rb
@@ -5,12 +5,15 @@
 class RecordImporter < Darlingtonia::HyraxRecordImporter
   attr_reader :actor_record_importer
   attr_reader :collection_record_importer
+  attr_reader :info_stream, :error_stream
 
   def initialize(error_stream:, info_stream:, attributes: {})
-    @actor_record_importer = ::ActorRecordImporter.new(error_stream: error_stream, info_stream: info_stream, attributes: attributes)
-    @collection_record_importer = ::CollectionRecordImporter.new(error_stream: error_stream, info_stream: info_stream, attributes: attributes)
+    @info_stream = info_stream
+    @error_stream = error_stream
+    @actor_record_importer = ::ActorRecordImporter.new(error_stream: @error_stream, info_stream: @info_stream, attributes: attributes)
+    @collection_record_importer = ::CollectionRecordImporter.new(error_stream: @error_stream, info_stream: @info_stream, attributes: attributes)
 
-    super(error_stream: error_stream, info_stream: info_stream, attributes: attributes)
+    super(error_stream: @error_stream, info_stream: @info_stream, attributes: attributes)
   end
 
   def import(record:)

--- a/app/jobs/start_csv_import_job.rb
+++ b/app/jobs/start_csv_import_job.rb
@@ -4,12 +4,22 @@ class StartCsvImportJob < ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
   def perform(csv_import_id)
-    csv_import = CsvImport.find csv_import_id
-    log_stream = Darlingtonia.config.default_info_stream
-    log_stream << "Starting import with batch ID: #{csv_import_id}"
-    importer = CalifornicaImporter.new(csv_import)
+    @csv_import = CsvImport.find csv_import_id
+    setup_logging
+    @info_stream << "StartCsvImportJob ~ Starting import with batch ID: #{csv_import_id}"
+    importer = CalifornicaImporter.new(@csv_import, info_stream: @info_stream, error_stream: @error_stream)
     importer.import
   rescue => e
-    log_stream << "CsvImportJob failed: #{e.message}"
+    @error_stream << "StartCsvImportJob failed: #{e.message}"
+  end
+
+  def ingest_log_filename
+    Rails.root.join('log', "ingest_#{@csv_import.id}.log").to_s
+  end
+
+  def setup_logging
+    @ingest_log   = Logger.new(ingest_log_filename)
+    @info_stream  = CalifornicaLogStream.new(logger: @ingest_log, severity: Logger::INFO)
+    @error_stream = CalifornicaLogStream.new(logger: @ingest_log, severity: Logger::ERROR)
   end
 end

--- a/spec/system/import_and_show_work_spec.rb
+++ b/spec/system/import_and_show_work_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Import and Display a Work', :clean, type: :system, inline_jobs: true, js: true do
-  subject(:importer) { CalifornicaImporter.new(csv_import) }
+  subject(:importer) { CalifornicaImporter.new(csv_import, info_stream: [], error_stream: []) }
   let(:csv_import) { FactoryBot.create(:csv_import, user: user, manifest: manifest) }
   let(:manifest) { Rack::Test::UploadedFile.new(csv_file, 'text/csv') }
   let(:csv_file)   { File.join(fixture_path, 'coordinates_example.csv') }
@@ -12,8 +12,6 @@ RSpec.describe 'Import and Display a Work', :clean, type: :system, inline_jobs: 
 
   # Cleanup log files after each test run
   after do
-    File.delete(importer.ingest_log_filename) if File.exist? importer.ingest_log_filename
-    File.delete(importer.error_log_filename) if File.exist? importer.error_log_filename
     File.delete(ENV['MISSING_FILE_LOG']) if File.exist?(ENV['MISSING_FILE_LOG'])
   end
 


### PR DESCRIPTION
Previously, log messages during ingest ended up in a few different files. This commit moves them to:

- Errors during a CsvRowImportJob end up in the associated csvrow object's "error_messages" field, which is stored in the database and visible in the dashboard.
- Errors that occur outside of any CsvRowImportJob get logged in the ingest_X.log file (also with info-level messages), which is written to the filesystem and visible from the dashboard.