### PR TITLE
Fix - Edit page fails to render visibility badge in dev (not on servers)

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -2,7 +2,7 @@
 
 # Override this constant from the hyrax gem so that we
 # can add the "discovery" visibility to Californica.
-Californica::Application.config.after_initialize do
+Rails.application.config.to_prepare do
   Hyrax::PermissionBadge.send(:remove_const, :VISIBILITY_LABEL_CLASS)
   Hyrax::PermissionBadge::VISIBILITY_LABEL_CLASS = {
     authenticated: "label-info",


### PR DESCRIPTION
Edit page failed to render visibility badge in dev (not on servers)

The work edit page failed to render due to an error related to the "discovery"-level visibility badge.

This happened only in development, not in production. That's because this line was invoked in production:
https://github.com/UCLALibrary/californica/blob/a6e251a1692aecb073a9928d6d6f1c91e9b38700/config/initializers/hyrax.rb#L13

But per this discussion:
https://stackoverflow.com/questions/8895103/how-can-i-keep-my-initializer-configuration-from-being-lost-in-development-mode
it ran once in development but then reset on subsequent requests.

<img width="1139" alt="Screen Shot 2019-07-17 at 10 04 51 AM" src="https://user-images.githubusercontent.com/751697/61395483-60802c80-a87a-11e9-96e1-c0aefc27af1c.png">

---

Changes to be committed:
+ modified: `config/initializers/hyrax.rb`