### PR TITLE
On ingest, don't create new record if the title starts with "DUPLICATE"

### DIFF
--- a/app/assets/markdown/importer_guide.md
+++ b/app/assets/markdown/importer_guide.md
@@ -113,6 +113,8 @@ Examples:
 - `[Fannie Lou Hamer, Mississippi Freedom Democratic Party delegate, at the Democratic National Convention, Atlantic City, New Jersey, August 1964] / [WKL].` (single value)
 - `[Fannie Lou Hamer, Mississippi Freedom Democratic Party delegate, at the Democratic National Convention, Atlantic City, New Jersey, August 1964] / [WKL].|~|Fannie Lou Hamer Portrait` (multivalued)
 
+If the title begins with 'DUPLICATE' (case sensitive), then no new record will be created. If a record already exists with the same ark, then that record will be updated as usual. Such records can be found and manually deleted by searching for 'DUPLICATE'
+
 ## Other Allowed Fields
 
 ### AltIdentifier.local

--- a/app/importers/actor_record_importer.rb
+++ b/app/importers/actor_record_importer.rb
@@ -61,6 +61,8 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
   def create_for(record:)
     info_stream << "event: record_import_started, row_id: #{@row_id}, ark: #{record.ark}\n"
 
+    raise(ArgumentError, 'Title starts "DUPLICATE" – record will not be imported.') if record.mapper.title[0].to_s.start_with?('DUPLICATE')
+
     additional_attrs = {
       uploaded_files: create_upload_files(record),
       depositor: @depositor.user_key

--- a/spec/importers/actor_record_importer_spec.rb
+++ b/spec/importers/actor_record_importer_spec.rb
@@ -45,5 +45,18 @@ RSpec.describe ActorRecordImporter, :clean do
         expect { importer.import(record: record) }.to raise_error(RuntimeError, /Validation failed/)
       end
     end
+
+    context 'if the record title starts with "DUPLICATE"' do
+      let(:metadata) do
+        {
+          'Title' => 'DUPLICATE: Comet in Moominland',
+          'Item ARK' => 'ark:/abc/123'
+        }
+      end
+
+      it 'raises an error' do
+        expect { importer.import(record: record) }.to raise_error(ArgumentError, 'Title starts "DUPLICATE" – record will not be imported.')
+      end
+    end
   end
 end


### PR DESCRIPTION
This change raises an AttributeError instead, with a useful message that gets stored in the CsvRowImport database and displayed on the dashboard.