### PR TITLE
Remove dependencies on HTTP request for IIIF manifest generation.

### DIFF
--- a/app/services/californica/manifest_builder_service.rb
+++ b/app/services/californica/manifest_builder_service.rb
@@ -10,5 +10,9 @@ module Californica
     def image_concerns
       @image_concerns ||= ([@curation_concern] + @curation_concern.ordered_members.to_a).select { |member| member.respond_to?(:master_file_path) && member.master_file_path }
     end
+
+    def root_url
+      "http://#{ENV['RAILS_HOST'] || 'localhost'}/concern/works/#{@curation_concern.id}/manifest"
+    end
   end
 end

--- a/app/views/manifest.json.jbuilder
+++ b/app/views/manifest.json.jbuilder
@@ -11,7 +11,8 @@ json.sequences [''] do
   json.set! :@type, 'sc:Sequence'
   json.set! :@id, "#{@root_url}/sequence/normal"
   json.canvases @image_concerns do |child|
-    json.set! :@id, "#{@root_url}/canvas/#{child.id}"
+    canvas_uri = "#{@root_url}/canvas/#{CGI.escape(child.ark)}"
+    json.set! :@id, canvas_uri
     json.set! :@type, 'sc:Canvas'
     json.label child.title.first
     json.description child.description.first
@@ -20,7 +21,7 @@ json.sequences [''] do
     json.images [child] do |child_image|
       url = Hyrax.config.iiif_image_url_builder.call(
         CGI.escape(child_image.master_file_path),
-        request.base_url,
+        ENV['IIIF_SERVER_URL'],
         Hyrax.config.iiif_image_size_default
       )
 
@@ -37,14 +38,14 @@ json.sequences [''] do
           # The base url for the info.json file
           info_url = Hyrax.config.iiif_info_url_builder.call(
             CGI.escape(child_image.master_file_path),
-            ENV['IIIF_SERVER_URL'] || request.base_url
+            ENV['IIIF_SERVER_URL']
           )
 
           json.set! :@id, info_url
           json.profile 'http://iiif.io/api/image/2/level2.json'
         end
       end
-      json.on "#{request.base_url}/concern/works/#{@solr_doc.id}/manifest/canvas/#{child.id}"
+      json.on canvas_uri
     end
   end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -6,4 +6,8 @@ Flipflop.configure do
   feature :read_only,
           default: false,
           description: "Put the system into read-only mode disabling changes and uploads. Do not close this session before re-enabling read/write -- you will not be able to login."
+
+  feature :cache_manifests,
+          default: true,
+          description: "Cache IIIF manifests on the filesystem. Cached manifests will be invalidated whenever a document is reindexed to solr."
 end

--- a/spec/services/californica/manifest_builder_service_spec.rb
+++ b/spec/services/californica/manifest_builder_service_spec.rb
@@ -53,4 +53,18 @@ RSpec.describe Californica::ManifestBuilderService do
       end
     end
   end
+
+  describe '#root_url' do
+    it 'uses ENV[\'RAILS_HOST\']' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('RAILS_HOST').and_return('my.url')
+      expect(service.root_url).to eq "http://my.url/concern/works/#{work.id}/manifest"
+    end
+
+    it 'defaults to use localhost' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('RAILS_HOST').and_return(nil)
+      expect(service.root_url).to eq "http://localhost/concern/works/#{work.id}/manifest"
+    end
+  end
 end

--- a/spec/views/manifest.json.jbuilder_spec.rb
+++ b/spec/views/manifest.json.jbuilder_spec.rb
@@ -6,12 +6,17 @@ RSpec.describe "manifest", type: :view do
   let(:master_file_path) { 'a/b.tif' }
   let(:work) { FactoryBot.create(:work, master_file_path: master_file_path) }
   let(:solr_doc) { SolrDocument.find(work.id) }
-  let(:image_concerns) { Californica::ManifestBuilderService.new(curation_concern: work).image_concerns }
+  let(:builder_service) { Californica::ManifestBuilderService.new(curation_concern: work) }
+  let(:image_concerns) { builder_service.image_concerns }
+  let(:root_url) { builder_service.root_url }
 
   before do
-    assign(:root_url, 'http://localhost:3000/manifest')
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('RAILS_HOST').and_return('my.url')
+
     assign(:solr_doc, solr_doc)
     assign(:image_concerns, image_concerns)
+    assign(:root_url, root_url)
   end
 
   it "displays a valid IIIF Presentation API manifest" do
@@ -21,16 +26,16 @@ RSpec.describe "manifest", type: :view do
 {
   "@context": "http://iiif.io/api/presentation/2/context.json",
   "@type": "sc:Manifest",
-  "@id": "http://localhost:3000/manifest",
+  "@id": "http://my.url/concern/works/#{work.id}/manifest",
   "label": "#{work.title.first}",
   "description": "#{work.description.first}",
   "sequences": [
     {
       "@type": "sc:Sequence",
-      "@id": "http://localhost:3000/manifest/sequence/normal",
+      "@id": "http://my.url/concern/works/#{work.id}/manifest/sequence/normal",
       "canvases": [
         {
-          "@id": "http://localhost:3000/manifest/canvas/#{work.id}",
+          "@id": "http://my.url/concern/works/#{work.id}/manifest/canvas/#{CGI.escape(work.ark)}",
           "@type": "sc:Canvas",
           "label": "#{work.title.first}",
           "description": "#{work.description.first}",
@@ -51,7 +56,7 @@ RSpec.describe "manifest", type: :view do
                   "profile": "http://iiif.io/api/image/2/level2.json"
                 }
               },
-              "on": "http://test.host/concern/works/#{work.id}/manifest/canvas/#{work.id}"
+              "on": "http://my.url/concern/works/#{work.id}/manifest/canvas/#{CGI.escape(work.ark)}"
             }
           ]
         }

--- a/spec/views/manifest.json.jbuilder_with_child_spec.rb
+++ b/spec/views/manifest.json.jbuilder_with_child_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe "manifest", type: :view do
   let(:work) { FactoryBot.create(:work, child_work: child_work) }
   let(:child_work) { FactoryBot.create(:work, master_file_path: master_file_path) }
   let(:solr_doc) { SolrDocument.find(work.id) }
-  let(:image_concerns) { Californica::ManifestBuilderService.new(curation_concern: work).image_concerns }
+  let(:builder_service) { Californica::ManifestBuilderService.new(curation_concern: work) }
+  let(:image_concerns) { builder_service.image_concerns }
+  let(:root_url) { builder_service.root_url }
 
   before do
-    assign(:root_url, 'http://localhost:3000/manifest')
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('RAILS_HOST').and_return('my.url')
+
+    assign(:root_url, root_url)
     assign(:solr_doc, solr_doc)
     assign(:image_concerns, image_concerns)
   end
@@ -22,16 +27,16 @@ RSpec.describe "manifest", type: :view do
 {
   "@context": "http://iiif.io/api/presentation/2/context.json",
   "@type": "sc:Manifest",
-  "@id": "http://localhost:3000/manifest",
+  "@id": "http://my.url/concern/works/#{work.id}/manifest",
   "label": "#{work.title.first}",
   "description": "#{work.description.first}",
   "sequences": [
     {
       "@type": "sc:Sequence",
-      "@id": "http://localhost:3000/manifest/sequence/normal",
+      "@id": "http://my.url/concern/works/#{work.id}/manifest/sequence/normal",
       "canvases": [
         {
-          "@id": "http://localhost:3000/manifest/canvas/#{child_work.id}",
+          "@id": "http://my.url/concern/works/#{work.id}/manifest/canvas/#{CGI.escape(child_work.ark)}",
           "@type": "sc:Canvas",
           "label": "#{child_work.title.first}",
           "description": "#{child_work.description.first}",
@@ -52,7 +57,7 @@ RSpec.describe "manifest", type: :view do
                   "profile": "http://iiif.io/api/image/2/level2.json"
                 }
               },
-              "on": "http://test.host/concern/works/#{work.id}/manifest/canvas/#{child_work.id}"
+              "on": "http://my.url/concern/works/#{work.id}/manifest/canvas/#{CGI.escape(child_work.ark)}"
             }
           ]
         }


### PR DESCRIPTION
Previously, building IIIF manifests could only be done in the context of an HTTP request, from which a URL was extracted for use in IIIF identifiers. This commit derives those identifiers from other sources so that manifests can be generated outside the HTTP request cycle, for example immediately upon ingest.