### PR TITLE
Configure .env files so app can be run natively

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,0 +1,44 @@
+# Environment variables for configuring the californica web server and its sidekiq workers.
+# This file serves as a base and an example for other configurations.
+
+PROJECT_NAME=californica
+DATABASE_ADAPTER=mysql2
+
+### NOTE: only uncomment/provide the DATABASE_NAME below *if* this is an environment-specific dotenv file (like .env.development or .env.test)
+# DATABASE_NAME=californica_development
+# DATABASE_NAME=californica_test
+
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=password
+CABLE_CHANNEL_PREFIX=californica_development
+CSV_FILE=/opt/data/sample_data_set_la_daily_news/dlcs-ladnn-2018-09-06.csv
+DATABASE_HOST=127.0.0.1
+DATABASE_MIN_MESSAGES=warning
+DATABASE_PASSWORD=californica
+DATABASE_POOL=25
+DATABASE_USERNAME=californica
+FEDORA_BASE_PATH=/dev
+FEDORA_PASSWORD=fedoraAdmin
+FEDORA_TEST_BASE_PATH=/test
+FEDORA_TEST_URL=http://localhost:8986/rest
+FEDORA_URL=http://localhost:8984/rest
+FEDORA_USER=fedoraAdmin
+GEONAMES_USERNAME=
+IMPORT_FILE_PATH=./data
+RAILS_HOST=localhost
+RAILS_SERVE_STATIC_FILES=true
+REDIS_CABLE_DB=1
+# hyrax/californica uses REDIS_HOST and REDIS_PORT, but sidekiq uses REDIS_URL
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_URL=redis://localhost:6379/0
+SIDEKIQ_WORKERS=7
+SOLR_TEST_URL=http://localhost:8985/solr/californica
+SOLR_URL=http://solr:8983/solr/californica
+
+
+# The following variables are passed to the browser as is. Therefore, they should use the URLs to which the services map on the host, not the URLs used within docker containers.
+
+# If there is an external IIIF server, uncomment; else, leave commented and californica will use its (less performant but integrated) RIIIF
+IIIF_SERVER_URL=https://s-u-cantaloupe01.library.ucla.edu/cantaloupe/iiif/2/
+URSUS_HOST=localhost:3003

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
       - fedora_test
       - solr_test
     env_file:
-      - ./docker.env
+      - ./default.env # must come first to be overloaded
+      - ./docker.env # must come last to overload default
     stdin_open: true
     tty: true
     ports:
@@ -37,7 +38,8 @@ services:
       - fedora_test
       - solr_test
     env_file:
-      - ./docker.env
+      - ./default.env # must come first to be overloaded
+      - ./docker.env # must come last to overload default
     volumes:
       - .:/californica
       - ./data:/opt/data

--- a/docker.env
+++ b/docker.env
@@ -1,44 +1,8 @@
-# Environment variables for configuring the californica web server and its sidekiq workers.
-# This file configures the app for use in our docker dev environment, and serves as an example for other configurations.
-
-PROJECT_NAME=californica
-DATABASE_ADAPTER=mysql2
-
-### NOTE: only uncomment/provide the DATABASE_NAME below *if* this is an environment-specific dotenv file (like .env.development or .env.test)
-# DATABASE_NAME=californica_development
-# DATABASE_NAME=californica_test
-
-ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=password
-CABLE_CHANNEL_PREFIX=californica_development
-CSV_FILE=/opt/data/sample_data_set_la_daily_news/dlcs-ladnn-2018-09-06.csv
 DATABASE_HOST=db
-DATABASE_MIN_MESSAGES=warning
-DATABASE_PASSWORD=californica
-DATABASE_POOL=25
-DATABASE_USERNAME=californica
-FEDORA_BASE_PATH=/dev
-FEDORA_PASSWORD=fedoraAdmin
-FEDORA_TEST_BASE_PATH=/test
 FEDORA_TEST_URL=http://fedora_test:8080/rest
 FEDORA_URL=http://fedora:8080/rest
-FEDORA_USER=fedoraAdmin
-GEONAMES_USERNAME=
 IMPORT_FILE_PATH=/opt/data
-RAILS_HOST=localhost
-RAILS_SERVE_STATIC_FILES=true
-REDIS_CABLE_DB=1
-# hyrax/californica uses REDIS_HOST and REDIS_PORT, but sidekiq uses REDIS_URL
 REDIS_HOST=redis
-REDIS_PORT=6379
 REDIS_URL=redis://redis:6379/0
-SIDEKIQ_WORKERS=7
 SOLR_TEST_URL=http://solr_test:8983/solr/californica
 SOLR_URL=http://solr:8983/solr/californica
-
-
-# The following variables are passed to the browser as is. Therefore, they should use the URLs to which the services map on the host, not the URLs used within docker containers.
-
-# If there is an external IIIF server, uncomment; else, leave commented and californica will use its (less performant but integrated) RIIIF
-IIIF_SERVER_URL=https://s-u-cantaloupe01.library.ucla.edu/cantaloupe/iiif/2/
-URSUS_HOST=localhost:3003


### PR DESCRIPTION
This moves most of the environment variables from docker.env to default.env, changing values specific to our docker setup to values that allow a native-running rails process to connect to services running in docker containers.

To run natively, run `ln -s default.env .env` to create a symlink.