### PR TITLE
fix to populate access_copy from File Name

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -4,7 +4,7 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   attr_reader :row_number
 
   CALIFORNICA_TERMS_MAP = {
-    access_copy: "Access copy",
+    access_copy: "access_copy",
     alternative_title: ["AltTitle.other",
                         "AltTitle.parallel",
                         "AltTitle.translated",
@@ -115,13 +115,7 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   end
 
   def access_copy
-    path = map_field(:access_copy).first.to_s.strip.sub(/^\//, '')
-    return nil if path.empty?
-    if path.start_with?('Masters/')
-      path
-    else
-      'Masters/dlmasters/' + path
-    end
+    map_field(:access_copy).first || preservation_copy
   end
 
   def ark

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -143,6 +143,27 @@ RSpec.describe CalifornicaMapper do
     end
   end
 
+  describe '#access_copy' do
+    context 'when the column is filled' do
+      let(:metadata) { { 'access_copy' => 'https://my.cantaloupe/iiif/2/abcxyz' } }
+
+      it 'uses that value' do
+        expect(mapper.access_copy).to eq 'https://my.cantaloupe/iiif/2/abcxyz'
+      end
+    end
+
+    context 'when the column is empty' do
+      let(:metadata) do
+        { 'File Name' => 'abc/xyz.tif',
+          'access_copy' => '' }
+      end
+
+      it 'uses preservation_copy' do
+        expect(mapper.access_copy).to eq 'Masters/dlmasters/abc/xyz.tif'
+      end
+    end
+  end
+
   describe '#preservation_copy' do
     context 'when the path starts with a \'/\'' do
       let(:metadata) { { 'File Name' => '/Masters/dlmasters/abc/xyz.tif' } }


### PR DESCRIPTION
This fixes a bug that prevented images from displaying for newly-imported works. The field access_copy should eventually be filled from a new CSV column created by bucketeer. This column is not yet ready, however, so for now we will continue to populate it from "File Name".