### PR TITLE
Fixes to Work and Collection forms

### DIFF
--- a/app/forms/hyrax/work_form.rb
+++ b/app/forms/hyrax/work_form.rb
@@ -35,8 +35,27 @@ module Hyrax
       :support,
       :uniform_title
     ]
+    self.terms -= [:based_near]
 
     self.required_fields = [:title, :ark, :rights_statement]
+
+    ##
+    # Fields that are automatically drawn on the page above the fold
+    #
+    # @return [Enumerable<Symbol>] symbols representing each primary term
+    def primary_terms
+      primary = required_fields + [:access_copy, :preservation_copy]
+      primary = (primary & terms)
+
+      (required_fields - primary).each do |missing|
+        Rails.logger.warn("The form field #{missing} is configured as a " \
+                          'required field, but not as a term. This can lead ' \
+                          'to unexpected behavior. Did you forget to add it ' \
+                          "to `#{self.class}#terms`?")
+      end
+
+      primary
+    end
 
     # Make some fields read-only
     def readonly?(field)

--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,0 +1,2 @@
+<%= f.input :language, as: :select, collection: Californica::LanguageService.select_options,
+    input_html: { class: 'form-control', multiple: true } %>

--- a/spec/forms/hyrax/child_work_form_spec.rb
+++ b/spec/forms/hyrax/child_work_form_spec.rb
@@ -28,4 +28,18 @@ RSpec.describe Hyrax::ChildWorkForm do
       :rights_holder
     )
   end
+
+  it 'doesn\'t have built-in terms we don\'t want' do
+    expect(form.terms).not_to include(:based_near)
+  end
+
+  it 'has the right terms above the fold' do
+    expect(form.primary_terms).to eq [
+      :title,
+      :ark,
+      :rights_statement,
+      :access_copy,
+      :preservation_copy
+    ]
+  end
 end

--- a/spec/forms/hyrax/work_form_spec.rb
+++ b/spec/forms/hyrax/work_form_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe Hyrax::WorkForm do
       :uniform_title
     )
   end
+
+  it 'doesn\'t have built-in terms we don\'t want' do
+    expect(form.terms).not_to include(:based_near)
+  end
+
+  it 'has the right terms above the fold' do
+    expect(form.primary_terms).to eq [
+      :title,
+      :ark,
+      :rights_statement,
+      :access_copy,
+      :preservation_copy
+    ]
+  end
 end

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Edit an existing collection', :clean, type: :system, js: true do
       publisher: ['Old Pub'],
       date_created: ['Old Creation Date'],
       subject: ['Old Subj'],
-      language: ['Old Lang'],
+      language: ['ang'],
       description: ['Old Desc'],
       resource_type: ['http://id.loc.gov/vocabulary/resourceTypes/col'], # "collection"
       extent: ['Old Extent'],
@@ -72,7 +72,7 @@ RSpec.describe 'Edit an existing collection', :clean, type: :system, js: true do
       expect(find_field('Publisher').value).to eq 'Old Pub'
       expect(find_field('Date Created').value).to eq 'Old Creation Date'
       expect(find_field('Subject').value).to eq 'Old Subj'
-      expect(find_field('Language').value).to eq 'Old Lang'
+      expect(page).to have_select('Language', selected: 'English, Old (ca. 450-1100)', multiple: true)
       expect(find_field('Resource type').value).to eq ["http://id.loc.gov/vocabulary/resourceTypes/col"]
       expect(find_field('Extent').value).to eq 'Old Extent'
       expect(find_field('Caption').value).to eq 'Old Cap'

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Edit an existing work', :clean, type: :system, js: true do
       extent: ['Old Extent'],
       funding_note: ['Old Fund Note'],
       genre: ['Old Genre'],
-      language: ['Old Lang'],
+      language: ['ang'],
       latitude: ['Old Lat'],
       local_identifier: ['Old Local ID'],
       location: ['Old Loc'],
@@ -74,7 +74,7 @@ RSpec.describe 'Edit an existing work', :clean, type: :system, js: true do
       expect(find_field('Extent').value).to eq 'Old Extent'
       expect(find_field('Funding Note').value).to eq 'Old Fund Note'
       expect(find_field('Genre').value).to eq 'Old Genre'
-      expect(find_field('Language').value).to eq 'Old Lang'
+      expect(page).to have_select('Language', selected: 'English, Old (ca. 450-1100)', multiple: true)
       expect(find_field('Latitude').value).to eq 'Old Lat'
       expect(find_field('Local Identifier').value).to eq 'Old Local ID'
       expect(find_field('Location').value).to eq 'Old Loc'
@@ -94,7 +94,6 @@ RSpec.describe 'Edit an existing work', :clean, type: :system, js: true do
       expect(find_field('Subject').value).to eq 'Old Subj'
       expect(find_field('Summary').value).to eq 'Old Summary'
       expect(find_field('Uniform title').value).to eq 'Old Uniform title'
-      expect(find(:xpath, '//label[@for="work_based_near"]').text).to eq 'Based Near'
       expect(first(:css, '#work_description').value).to eq 'Old Desc'
 
       # Edit some fields in the form


### PR DESCRIPTION
- Changes the 'Language' widget to a multiselect.
- Removes the field 'based_near', a hyrax default that we aren't using
- Moves preservation_copy and access_copy above the fold.