### PR TITLE
Use new IIIF service for manifests and thumbnails

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -30,26 +30,21 @@ class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
   end
 
   def thumbnail_url
-    # this record has an image path attached
+    iiif_url_base = Californica::ManifestBuilderService.new(curation_concern: object).iiif_url
 
-    access_copy = object.access_copy
     children = Array.wrap(object.members).clone
-
-    until access_copy || children.empty?
+    until iiif_url_base || children.empty?
       child = children.shift
+      iiif_url_base = Californica::ManifestBuilderService.new(curation_concern: child).iiif_url
 
-      if (child.respond_to? 'access_copy') && !child.access_copy.nil?
-        access_copy = child.access_copy
-      else
-        grandchildren = Array.wrap(child.members).clone
-        until access_copy || grandchildren.empty?
-          grandchild = grandchildren.shift
-          access_copy = grandchild.access_copy
-        end
+      grandchildren = Array.wrap(child.members).clone
+      until iiif_url_base || grandchildren.empty?
+        grandchild = grandchildren.shift
+        iiif_url_base = Californica::ManifestBuilderService.new(curation_concern: grandchild).iiif_url
       end
     end
 
-    return nil unless access_copy
-    "#{ENV['IIIF_SERVER_URL']}#{CGI.escape(access_copy)}/full/!200,200/0/default.jpg"
+    return nil unless iiif_url_base
+    "#{iiif_url_base}/full/!200,200/0/default.jpg"
   end
 end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -63,16 +63,15 @@ class WorkIndexer < Hyrax::WorkIndexer
 
   def thumbnail_url
     # this record has an image path attached
-    access_copy = object.access_copy
+    iiif_url_base = Californica::ManifestBuilderService.new(curation_concern: object).iiif_url
     children = Array.wrap(object.members).clone
-    until access_copy || children.empty?
+    until iiif_url_base || children.empty?
       child = children.shift
-      next unless child.respond_to? :access_copy
-      access_copy = child.access_copy
+      iiif_url_base = Californica::ManifestBuilderService.new(curation_concern: child).iiif_url
     end
 
-    return nil unless access_copy
-    "#{ENV['IIIF_SERVER_URL']}#{CGI.escape(access_copy)}/full/!200,200/0/default.jpg"
+    return nil unless iiif_url_base
+    "#{iiif_url_base}/full/!200,200/0/default.jpg"
   end
 
   # The 'to_a' is needed to force ActiveTriples::Relation to resolve into the String value(s), else you get an error trying to parse the date.

--- a/app/services/californica/manifest_builder_service.rb
+++ b/app/services/californica/manifest_builder_service.rb
@@ -7,6 +7,18 @@ module Californica
       @curation_concern = curation_concern
     end
 
+    def iiif_url
+      if !(@curation_concern.respond_to? :access_copy) || @curation_concern.access_copy.nil?
+        nil
+      elsif @curation_concern.access_copy.start_with?(/https?\:\/\//)
+        @curation_concern.access_copy
+      elsif @curation_concern.access_copy.start_with?(/ark\:\//)
+        ENV['IIIF_SERVICE_URL'] + CGI.escape(@curation_concern.access_copy)
+      else
+        ENV['IIIF_SERVER_URL'] + CGI.escape(@curation_concern.access_copy)
+      end
+    end
+
     def image_concerns
       @image_concerns ||= ([@curation_concern] + @curation_concern.ordered_members.to_a).select { |member| member.respond_to?(:access_copy) && member.access_copy }
     end

--- a/app/views/manifest.json.jbuilder
+++ b/app/views/manifest.json.jbuilder
@@ -11,6 +11,7 @@ json.sequences [''] do
   json.set! :@type, 'sc:Sequence'
   json.set! :@id, "#{@root_url}/sequence/normal"
   json.canvases @image_concerns do |child|
+    child_iiif_service = Californica::ManifestBuilderService.new(curation_concern: child)
     canvas_uri = "#{@root_url}/canvas/#{CGI.escape(child.ark)}"
     json.set! :@id, canvas_uri
     json.set! :@type, 'sc:Canvas'
@@ -18,28 +19,19 @@ json.sequences [''] do
     json.description child.description.first
     json.width 640
     json.height 480
-    json.images [child] do |child_image|
-      url = Hyrax.config.iiif_image_url_builder.call(
-        CGI.escape(child_image.access_copy),
-        ENV['IIIF_SERVER_URL'],
-        Hyrax.config.iiif_image_size_default
-      )
-
+    json.images [child] do
       json.set! :@type, 'oa:Annotation'
       json.motivation 'sc:painting'
       json.resource do
         json.set! :@type, 'dctypes:Image'
-        json.set! :@id, url
+        json.set! :@id, child_iiif_service.iiif_url + '/full/600,/0/default.jpg'
         json.width 640
         json.height 480
         json.service do
           json.set! :@context, 'http://iiif.io/api/image/2/context.json'
 
           # The base url for the info.json file
-          info_url = Hyrax.config.iiif_info_url_builder.call(
-            CGI.escape(child_image.access_copy),
-            ENV['IIIF_SERVER_URL']
-          )
+          info_url = child_iiif_service.iiif_url
 
           json.set! :@id, info_url
           json.profile 'http://iiif.io/api/image/2/level2.json'

--- a/default.env
+++ b/default.env
@@ -41,4 +41,5 @@ SOLR_URL=http://solr:8983/solr/californica
 
 # If there is an external IIIF server, uncomment; else, leave commented and californica will use its (less performant but integrated) RIIIF
 IIIF_SERVER_URL=https://s-u-cantaloupe01.library.ucla.edu/cantaloupe/iiif/2/
+IIIF_SERVICE_URL=https://iiif.library.ucla.edu/iiif/2/
 URSUS_HOST=localhost:3003

--- a/spec/services/californica/manifest_builder_service_spec.rb
+++ b/spec/services/californica/manifest_builder_service_spec.rb
@@ -3,18 +3,74 @@
 require 'rails_helper'
 
 RSpec.describe Californica::ManifestBuilderService do
-  let(:parent_image_path) { 'parent/image.tif' }
-  let(:child_image_path_1) { 'child/image_1.tif' }
-  let(:child_image_path_2) { 'child/image_2.tif' }
-  let(:child_work1) { FactoryBot.create(:child_work, access_copy: child_image_path_1) }
-  let(:child_work2) { FactoryBot.create(:child_work, access_copy: child_image_path_2) }
+  let(:parent_access_copy) { 'parent/image.tif' }
+  let(:child_access_copy_1) { 'child/image_1.tif' }
+  let(:child_access_copy_2) { 'child/image_2.tif' }
+  let(:child_work1) { FactoryBot.create(:child_work, access_copy: child_access_copy_1) }
+  let(:child_work2) { FactoryBot.create(:child_work, access_copy: child_access_copy_2) }
   let(:work) do
-    w = FactoryBot.create(:work, access_copy: parent_image_path)
+    w = FactoryBot.create(:work, access_copy: parent_access_copy)
     w.ordered_members << child_work1
     w.ordered_members << child_work2
     w
   end
   let(:service) { described_class.new(curation_concern: work) }
+
+  describe '#iiif_url' do
+    let(:work) { FactoryBot.create(:work, access_copy: parent_access_copy) }
+
+    context 'when called with a FileSet' do
+      let(:work) { FactoryBot.create(:file_set) }
+
+      it 'returns nil' do
+        expect(service.iiif_url).to be_nil
+      end
+    end
+
+    context 'when access_copy starts with \'http://\'' do
+      let(:parent_access_copy) { 'http://iiif.library.ucla.edu/iiif/2/finaltest1' }
+
+      it 'uses the link as is' do
+        expect(service.iiif_url).to eq 'http://iiif.library.ucla.edu/iiif/2/finaltest1'
+      end
+    end
+
+    context 'when access_copy starts with \'https://\'' do
+      let(:parent_access_copy) { 'https://iiif.library.ucla.edu/iiif/2/finaltest1' }
+
+      it 'uses the link as is' do
+        expect(service.iiif_url).to eq 'https://iiif.library.ucla.edu/iiif/2/finaltest1'
+      end
+    end
+
+    context 'when access_copy starts with \'Masters/\'' do
+      let(:parent_access_copy) { 'Masters/dlmasters/finaltest1' }
+
+      it 'creates a link to the old cantaloupe' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('IIIF_SERVER_URL').and_return('https://old.cantaloupe.url/iiif/2/')
+        expect(service.iiif_url).to eq 'https://old.cantaloupe.url/iiif/2/Masters%2Fdlmasters%2Ffinaltest1'
+      end
+    end
+
+    context 'when access_copy starts with \'ark:/\'' do
+      let(:parent_access_copy) { 'ark:/123/456' }
+
+      it 'creates a link to the new cantaloupe' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('IIIF_SERVICE_URL').and_return('https://new.cantaloupe.url/iiif/2/')
+        expect(service.iiif_url).to eq 'https://new.cantaloupe.url/iiif/2/ark%3A%2F123%2F456'
+      end
+    end
+
+    context 'when access_copy is nil' do
+      let(:parent_access_copy) { nil }
+
+      it 'returns nil' do
+        expect(service.iiif_url).to eq nil
+      end
+    end
+  end
 
   describe '#image_concerns' do
     it 'returns the set of works needed to create a manifest' do
@@ -22,7 +78,7 @@ RSpec.describe Californica::ManifestBuilderService do
     end
 
     context 'When the parent work has no access_copy' do
-      let(:parent_image_path) { nil }
+      let(:parent_access_copy) { nil }
 
       it 'returns the set of child works' do
         expect(service.image_concerns).to eq [child_work1, child_work2]
@@ -30,7 +86,7 @@ RSpec.describe Californica::ManifestBuilderService do
     end
 
     context 'When the parent work has no children' do
-      let(:work) { FactoryBot.create(:work, access_copy: parent_image_path) }
+      let(:work) { FactoryBot.create(:work, access_copy: parent_access_copy) }
 
       it 'returns only the parent' do
         expect(service.image_concerns).to eq [work]
@@ -46,7 +102,7 @@ RSpec.describe Californica::ManifestBuilderService do
     end
 
     context 'When the a child work has no access_copy' do
-      let(:child_image_path_1) { nil }
+      let(:child_access_copy_1) { nil }
 
       it 'does not include the child' do
         expect(service.image_concerns).to eq [work, child_work2]


### PR DESCRIPTION
- Creates a helper function which generates IIIF links from `access_copy`, determining whether they should point to the old Cantaloupe or the new IIIF server.
- Uses this helper function in generating manifests.
- Uses the helper function for thumbnails.