### PR TITLE
Precreate manifests

### DIFF
--- a/app/importers/californica_csv_parser.rb
+++ b/app/importers/californica_csv_parser.rb
@@ -48,6 +48,19 @@ class CalifornicaCsvParser < Darlingtonia::CsvParser
     []
   end
 
+  # Creates IIIF Manifests for each Work in a CSV. Does not create documents
+  # for Collection or ChildWork objects.
+  #
+  # @return nil
+  def build_iiif_manifests
+    records.each do |row|
+      next if ["Collection", "ChildWork", "Page"].include? row.mapper.metadata["Object Type"]
+      work = Work.find_by_ark(row.ark)
+      Californica::ManifestBuilderService.new(curation_concern: work).persist
+    end
+    nil
+  end
+
   # Given an array of Work arks that have had ChildWorks added to them during this import,
   # iterate through each and use the PageOrder objects to ensure the ChildWorks are
   # in the right order. In other works, ensure a manuscript's pages are ordered by the

--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -27,6 +27,7 @@ class CalifornicaImporter
     raise "CSV file #{@csv_file} did not validate" unless parser.validate
     Darlingtonia::Importer.new(parser: parser, record_importer: record_importer, info_stream: @info_stream, error_stream: @error_stream).import
     parser.order_child_works
+    parser.build_iiif_manifests
     parser.reindex_collections
   rescue => e
     @error_stream << "CsvImportJob failed: #{e.message}"

--- a/app/services/californica/manifest_builder_service.rb
+++ b/app/services/californica/manifest_builder_service.rb
@@ -39,7 +39,7 @@ module Californica
     end
 
     def persist
-      File.open(Rails.root.join('tmp', filesystem_cache_key + '.manifest.json'), 'w+') do |f|
+      File.open(Rails.root.join('tmp', filesystem_cache_key), 'w+') do |f|
         f.write render
       end
     end

--- a/spec/services/californica/manifest_builder_service_spec.rb
+++ b/spec/services/californica/manifest_builder_service_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Californica::ManifestBuilderService do
 
     before do
       allow(File).to receive(:open).and_call_original
-      allow(File).to receive(:open).with(Rails.root.join('tmp', key + '.manifest.json'), 'w+').and_yield(buffer)
+      allow(File).to receive(:open).with(Rails.root.join('tmp', key), 'w+').and_yield(buffer)
       allow(service).to receive(:filesystem_cache_key).and_return(key)
       allow(service).to receive(:render).and_return(content)
     end


### PR DESCRIPTION
Builds IIIF manifests for all works in an ingest (not ChildWorks or Collections), caching them to the filesystem.