### PR TITLE
Cache IIIF manifests to the Manifest Store Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,5 +79,6 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'simplecov', '~> 0.16.1'
   gem 'solr_wrapper', '>= 0.3'
+  gem 'webmock'
   gem 'xray-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     darlingtonia (3.2.2)
       active-fedora (>= 11.5.2)
@@ -314,6 +316,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hashdiff (1.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
     http_logger (0.5.1)
@@ -719,6 +722,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
+    safe_yaml (1.0.5)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.7.4)
@@ -840,6 +844,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.6.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -908,6 +916,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
   whenever
   xray-rails
 

--- a/spec/services/californica/manifest_builder_service_spec.rb
+++ b/spec/services/californica/manifest_builder_service_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Californica::ManifestBuilderService do
   let(:child_access_copy_2) { 'child/image_2.tif' }
   let(:child_work1) { FactoryBot.create(:child_work, access_copy: child_access_copy_1) }
   let(:child_work2) { FactoryBot.create(:child_work, access_copy: child_access_copy_2) }
+  let(:iiif_manifest_url) { manifest_store_url + work.ark + '/manifest' }
+  let(:manifest_store_url) { 'https://manifest.store.url/' }
   let(:work) do
     w = FactoryBot.create(:work, access_copy: parent_access_copy)
     w.ordered_members << child_work1
@@ -145,9 +147,34 @@ RSpec.describe Californica::ManifestBuilderService do
       allow(service).to receive(:render).and_return(content)
     end
 
-    it 'saves the manifest' do
+    it 'saves the manifest to the filesystem' do
       service.persist
       expect(buffer.string).to eq(content)
+    end
+
+    context 'When ENV[\'IIIF_MANIFEST_URL\'] exists' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('IIIF_MANIFEST_URL').and_return(manifest_store_url)
+      end
+
+      it 'saves the manifest to the filesystem' do
+        stub_request(:put, iiif_manifest_url).to_return(status: 200)
+        service.persist
+        expect(buffer.string).to eq(content)
+      end
+
+      it 'submits the manifest to the external service' do
+        stub = stub_request(:put, iiif_manifest_url).to_return(status: 200)
+        service.persist
+        expect(stub).to have_been_requested
+      end
+
+      it 'populates \'iiif_manifest_url\' if the request to the service succeeded' do
+        stub_request(:put, iiif_manifest_url).to_return(status: 200)
+        service.persist
+        expect(work.iiif_manifest_url).to eq iiif_manifest_url
+      end
     end
   end
 
@@ -261,16 +288,32 @@ RSpec.describe Californica::ManifestBuilderService do
   end
 
   describe '#root_url' do
-    it 'uses ENV[\'RAILS_HOST\']' do
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('RAILS_HOST').and_return('my.url')
-      expect(service.root_url).to eq "http://my.url/concern/works/#{work.id}/manifest"
+    context 'When ENV[\'IIIF_MANIFEST_URL\'] is not set' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('IIIF_MANIFEST_URL').and_return(nil)
+      end
+
+      it 'uses ENV[\'RAILS_HOST\']' do
+        allow(ENV).to receive(:[]).with('RAILS_HOST').and_return('my.url')
+        expect(service.root_url).to eq "http://my.url/concern/works/#{work.id}/manifest"
+      end
+
+      it 'defaults to use localhost' do
+        allow(ENV).to receive(:[]).with('RAILS_HOST').and_return(nil)
+        expect(service.root_url).to eq "http://localhost/concern/works/#{work.id}/manifest"
+      end
     end
 
-    it 'defaults to use localhost' do
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('RAILS_HOST').and_return(nil)
-      expect(service.root_url).to eq "http://localhost/concern/works/#{work.id}/manifest"
+    context 'When ENV[\'IIIF_MANIFEST_URL\'] exists' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('IIIF_MANIFEST_URL').and_return(manifest_store_url)
+      end
+
+      it 'points to the IIIF service, and uses the ark as identifier' do
+        expect(service.root_url).to eq manifest_store_url + work.ark + '/manifest'
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,11 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+# Use WebMock to stub HTTP requests
+require 'webmock/rspec'
+WebMock.enable!
+WebMock.allow_net_connect!
+
 if ENV['TRAVIS'] == 'true'
   require 'coveralls'
   Coveralls.wear!('rails')


### PR DESCRIPTION
If IIIF_MANIFEST_URL is set, submits the manifest to the service at that location in addition to saving it locally.