### PR TITLE
Add ingest duration to csv rows to record ingest time per row

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Metrics/AbcSize:
     - app/uploaders/csv_manifest_validator.rb
     - app/importers/collection_record_importer.rb
     - spec/jobs/mss_csv_import_job_spec.rb
+    - app/jobs/csv_row_import_job.rb
 
 Metrics/ClassLength:
   Enabled: true
@@ -43,7 +44,6 @@ Metrics/BlockLength:
     - 'lib/tasks/purge.rake'
     - app/models/ucla_metadata.rb
     - app/views/manifest.json.jbuilder
-
 
 Metrics/ModuleLength:
   Enabled: true
@@ -83,6 +83,7 @@ Metrics/MethodLength:
     - app/models/concerns/discoverable.rb
     - app/presenters/hyrax/californica_collection_presenter.rb
     - app/importers/californica_importer.rb
+    - app/jobs/csv_row_import_job.rb
 
 Metrics/ModuleLength:
   Enabled: true
@@ -120,7 +121,7 @@ RSpec/ExampleLength:
     - 'spec/uploaders/csv_manifest_validator_spec.rb'
     - 'spec/views**/*'
     - 'spec/views/manifest.json.jbuilder_spec.rb'
-    
+
 RSpec/LetSetup:
   Enabled: false
 

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class CsvRowImportJob < ActiveJob::Base
   def perform(row_id:)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     @row_id = row_id
     @row = CsvRow.find(@row_id)
     @metadata = JSON.parse(@row.metadata)
@@ -15,7 +16,9 @@ class CsvRowImportJob < ActiveJob::Base
                           actor_record_importer
                         end
     selected_importer.import(record: record)
-
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ingest_duration = end_time - start_time
+    @row.ingest_duration = ingest_duration
     @row.job_ids_completed << job_id
     @row.save
   rescue => e

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -18,7 +18,7 @@
       <% if @csv_import.elapsed_time == nil %>
         <span class="calculating">Calculating...</span>
       <% else %>
-        <%= @csv_import.elapsed_time.round %> seconds
+        <%= @csv_import.elapsed_time.round(3) %> seconds
       <% end %>
     </span>
     <br />
@@ -27,7 +27,7 @@
       <% if @csv_import.elapsed_time_per_record == nil %>
         <span class="calculating">Calculating...</span>
       <% else %>
-        <%= @csv_import.elapsed_time_per_record.round %> seconds
+        <%= @csv_import.elapsed_time_per_record.round(3) %> seconds
       <% end %>
     </span>
     <br />
@@ -55,6 +55,9 @@
         <th>
           Status
         </th>
+        <th>
+          Ingest Duration (in seconds)
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -65,6 +68,11 @@
           <td><%= csv_row.updated_at.strftime('%e %b %Y %l:%M %p') || "Unknown" %></td>
           <td><%= csv_row.error_messages || "" %></td>
           <td><%= csv_row.status || "Unknown" %></td>
+          <% if csv_row.ingest_duration == nil %>
+            <td>Unknown</td>
+          <% else %>
+          <td><%= csv_row.ingest_duration.round(3) || "Unknown" %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/db/migrate/20190830171825_add_ingest_duration_to_csv_row.rb
+++ b/db/migrate/20190830171825_add_ingest_duration_to_csv_row.rb
@@ -1,0 +1,5 @@
+class AddIngestDurationToCsvRow < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_rows, :ingest_duration, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190827235705) do
+ActiveRecord::Schema.define(version: 20190830171825) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20190827235705) do
     t.text "job_ids_queued"
     t.text "job_ids_completed"
     t.text "job_ids_errored"
+    t.float "ingest_duration", limit: 24
   end
 
   create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
       expect(page).to have_content("Average import time per record")
       expect(csv_import.record_count).to eq 2
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
+      expect(page).to have_content("Ingest Duration (in seconds)")
     end
   end
 end


### PR DESCRIPTION
https://jira.library.ucla.edu/browse/CAL-752

![image](https://user-images.githubusercontent.com/4259468/64044061-cbc84a00-cb1a-11e9-8ada-1b4b748fa2c1.png)

modified:   .rubocop.yml
modified:   app/jobs/csv_row_import_job.rb
modified:   app/views/csv_imports/show.html.erb
new file:   db/migrate/20190830171825_add_ingest_duration_to_csv_row.rb
modified:   db/schema.rb
modified:   spec/system/import_from_csv_spec.rb