### PR TITLE
Use manifests from the manifest-store service

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -79,7 +79,11 @@ class SolrDocument
   end
 
   def iiif_manifest_url
-    self[:iiif_manifest_url_ssi]
+    if Flipflop.use_manifest_store? && self[:iiif_manifest_url_ssi]
+      self[:iiif_manifest_url_ssi]
+    else
+      "/concern/works/#{id}/manifest"
+    end
   end
 
   def iiif_range

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,0 +1,4 @@
+<%= PulUvRails::UniversalViewer.script_tag %>
+<div class="viewer-wrapper">
+  <div class="uv viewer" data-uri="<%= presenter.iiif_manifest_url %>"></div>
+</div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -10,4 +10,8 @@ Flipflop.configure do
   feature :cache_manifests,
           default: true,
           description: "Cache IIIF manifests on the filesystem. Cached manifests will be invalidated whenever a document is reindexed to solr."
+
+  feature :use_manifest_store,
+          default: false,
+          description: "Load IIIF manifests from the external manifest-store service when possible."
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe SolrDocument do
   let(:solr_document) { described_class.new(fields) }
 
   let(:fields) do
-    { caption_tesim: [''],
+    { id: '456xyz',
+      caption_tesim: [''],
       dimensions_tesim: [''],
       extent_tesim: [''],
       funding_note_tesim: [''],
@@ -67,6 +68,37 @@ RSpec.describe SolrDocument do
 
   it 'has rights_holder' do
     expect(solr_document.rights_holder).to eq([''])
+  end
+
+  describe '#iiif_manifest_url' do
+    context 'when a url is stored and feature enabled' do
+      let(:fields) do
+        { iiif_manifest_url_ssi: 'https://manifest.store.url/abc123/manifest' }
+      end
+
+      it 'uses that url' do
+        allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
+        expect(solr_document.iiif_manifest_url).to eq 'https://manifest.store.url/abc123/manifest'
+      end
+    end
+
+    context 'when a url is stored but feature is disabled' do
+      let(:fields) do
+        { id: '456xyz',
+          iiif_manifest_url_ssi: 'https://manifest.store.url/abc123/manifest' }
+      end
+
+      it 'builds a local url' do
+        allow(Flipflop).to receive(:use_manifest_store?).and_return(false)
+        expect(solr_document.iiif_manifest_url).to eq '/concern/works/456xyz/manifest'
+      end
+    end
+
+    context 'when nothing is stored' do
+      it 'builds a local url' do
+        expect(solr_document.iiif_manifest_url).to eq '/concern/works/456xyz/manifest'
+      end
+    end
   end
 
   describe 'visibility' do


### PR DESCRIPTION
Feature is wrapped in a Flipflop toggle. If the flag is disabled, or if the 'iiif_manifest_url' field is empty, then defaults to serving a manifest directly from californica.

The flag is disabled by default, because we need to wait for CORS headers to be set on the service's end before the feature will work.