### PR TITLE
include viewingDirection in IIIF manifest

### DIFF
--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -39,9 +39,9 @@ module Hyrax
         render_manifest_file(key: key)
       else
         curation_concern = _curation_concern_type.find(params[:id]) unless curation_concern
-        builder_service = Californica::ManifestBuilderService.new(curation_concern: curation_concern)
-        @image_concerns = builder_service.image_concerns
-        @root_url = builder_service.root_url
+        @builder_service = Californica::ManifestBuilderService.new(curation_concern: curation_concern)
+        @image_concerns = @builder_service.image_concerns
+        @root_url = @builder_service.root_url
 
         manifest_json = render_to_string('/manifest.json')
         persist_manifest(key: key, json: manifest_json) if Flipflop.cache_manifests?

--- a/app/services/californica/manifest_builder_service.rb
+++ b/app/services/californica/manifest_builder_service.rb
@@ -9,7 +9,8 @@ module Californica
 
     def render
       renderer.render template: '/manifest.json',
-                      assigns: { root_url: root_url,
+                      assigns: { builder_service: self,
+                                 root_url: root_url,
                                  solr_doc: SolrDocument.find(@curation_concern.id),
                                  image_concerns: image_concerns }
     end
@@ -22,6 +23,16 @@ module Californica
       raise 'Cannot persist a IIIF manifest without an object ID. Did you forget to save this object?'
     end
 
+    def iiif_text_direction
+      if @curation_concern.iiif_text_direction
+        Qa::Authorities::Local.subauthority_for('iiif_text_directions')
+                              .find(@curation_concern.iiif_text_direction)
+                              .fetch('term')
+      end
+    rescue KeyError
+      nil
+    end
+
     def iiif_url
       if !(@curation_concern.respond_to? :access_copy) || @curation_concern.access_copy.nil?
         nil
@@ -32,6 +43,16 @@ module Californica
       else
         ENV['IIIF_SERVER_URL'] + CGI.escape(@curation_concern.access_copy)
       end
+    end
+
+    def iiif_viewing_hint
+      if @curation_concern.iiif_viewing_hint
+        Qa::Authorities::Local.subauthority_for('iiif_viewing_hints')
+                              .find(@curation_concern.iiif_viewing_hint)
+                              .fetch('term')
+      end
+    rescue KeyError
+      nil
     end
 
     def image_concerns

--- a/app/views/manifest.json.jbuilder
+++ b/app/views/manifest.json.jbuilder
@@ -6,6 +6,7 @@ json.set! :@type, 'sc:Manifest'
 json.set! :@id, @root_url
 json.label @solr_doc.title.first
 json.description @solr_doc.description.first
+json.viewingDirection @builder_service.iiif_text_direction if @builder_service.iiif_text_direction
 
 json.sequences [''] do
   json.set! :@type, 'sc:Sequence'

--- a/spec/views/manifest.json.jbuilder_spec.rb
+++ b/spec/views/manifest.json.jbuilder_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "manifest", type: :view do
     assign(:solr_doc, solr_doc)
     assign(:image_concerns, image_concerns)
     assign(:root_url, root_url)
+    assign(:builder_service, builder_service)
   end
 
   it "displays a valid IIIF Presentation API manifest" do

--- a/spec/views/manifest.json.jbuilder_with_child_spec.rb
+++ b/spec/views/manifest.json.jbuilder_with_child_spec.rb
@@ -4,7 +4,14 @@ require 'cgi'
 
 RSpec.describe "manifest", type: :view do
   let(:access_copy) { 'a/b/c.tif' }
-  let(:work) { FactoryBot.create(:work, child_work: child_work) }
+  let(:work) do
+    FactoryBot.create(
+      :work,
+      child_work: child_work,
+      iiif_text_direction: 'http://iiif.io/api/presentation/2#leftToRightDirection',
+      iiif_viewing_hint: 'http://iiif.io/api/presentation/2#pagedHint'
+    )
+  end
   let(:child_work) { FactoryBot.create(:work, access_copy: access_copy) }
   let(:solr_doc) { SolrDocument.find(work.id) }
   let(:builder_service) { Californica::ManifestBuilderService.new(curation_concern: work) }
@@ -18,6 +25,7 @@ RSpec.describe "manifest", type: :view do
     assign(:root_url, root_url)
     assign(:solr_doc, solr_doc)
     assign(:image_concerns, image_concerns)
+    assign(:builder_service, builder_service)
   end
 
   it "displays manifest for a work with child works" do
@@ -30,6 +38,7 @@ RSpec.describe "manifest", type: :view do
   "@id": "http://my.url/concern/works/#{work.id}/manifest",
   "label": "#{work.title.first}",
   "description": "#{work.description.first}",
+  "viewingDirection": "left-to-right",
   "sequences": [
     {
       "@type": "sc:Sequence",


### PR DESCRIPTION
viewingHint is *not* being included at this time, as Universal Viewer does not correctly match paired pages when there are extra initial images (e.g. an exterior photo).