### PR TITLE
configure rspec to persist failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
+# Rspec's list of (locally) failing tests
+spec/examples.txt
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  # config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:


### PR DESCRIPTION
this enables it to be run with the `--only-failures` and `--next-failure` flags.