### PR TITLE
CAL-753 Display ingest metrics on csv_import_show page

### DIFF
--- a/app/assets/stylesheets/_ingest_metrics.scss
+++ b/app/assets/stylesheets/_ingest_metrics.scss
@@ -1,0 +1,48 @@
+@import 'variables';
+
+.ingest-metrics {
+  table, th, td {
+    border: 1px solid #D1D1D1;
+    text-align: center;
+    background: white;
+  }
+}
+
+.csv_logs {
+  table, th, td {
+    border: .5px solid #D1D1D1;
+    padding: 0px;
+    margin: 0px;
+  }
+}
+
+.ingest-metrics-table {
+  background-color: $ingest-lt-gray;
+  padding: 1px 10px 25px 10px;
+}
+
+.ingest-small {
+  color: $ingest-dk-gray;
+}
+
+.text-center {
+  td {
+    text-align: center;
+  }
+}
+
+.ingest-hr {
+  border: 1px solid #D1D1D1;
+}
+
+.ingest-lt-gray {
+  color: $ingest-lt-gray;
+}
+
+.ingest-md-gray {
+  color: $ingest-md-gray;
+}
+
+.ingest-dk-gray {
+  color: $ingest-dk-gray;
+}

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -26,3 +26,7 @@ $navbar-transparent-link-active-color: $ucla-blue-lighter !default;
 $navbar-transparent-link-active-bg: #585050 !default;
 
 $navbar-default-bg: $californica-yellow !default;
+
+$ingest-lt-gray: #dcdcdc;
+$ingest-md-gray: #7D7D7D;
+$ingest-dk-gray: #5E5E5E;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,6 +19,3 @@
 #facet-panel-collapse {
   background: inherit;
 }
-.calculating {
-  color: gray
-}

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -16,6 +16,7 @@
 @import 'hyrax/hyrax';
 @import 'variables';
 @import 'feedback_link';
+@import 'ingest_metrics';
 
 .brand-logo img {
   height: 28px;

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -74,21 +74,21 @@ class CsvImportsController < ApplicationController
     def min
       if @csv_rows.count == @csv_import.record_count
         @min_ingest_duration = row_times.minimum(:ingest_duration)
-        @min_ingest_duration.round(3)
+        @min_ingest_duration.round(2)
       end
     end
 
     def max
       if @csv_rows.count == @csv_import.record_count
         @max_ingest_duration = row_times.maximum(:ingest_duration)
-        @max_ingest_duration.round(3)
+        @max_ingest_duration.round(2)
       end
     end
 
     def mean
       if @csv_rows.count == @csv_import.record_count
         @mean_ingest_duration = row_times.average(:ingest_duration)
-        @mean_ingest_duration.round(3)
+        @mean_ingest_duration.round(2)
       end
     end
 
@@ -98,7 +98,7 @@ class CsvImportsController < ApplicationController
         durations = @get_ingest_duration_rows.map(&:ingest_duration)
         sorted = durations.compact.sort
         len = sorted.length
-        ((sorted[(len - 1) / 2] + sorted[len / 2]) / 2.0).round(3) if len.positive?
+        ((sorted[(len - 1) / 2] + sorted[len / 2]) / 2.0).round(2) if len.positive?
       end
     end
 
@@ -108,7 +108,7 @@ class CsvImportsController < ApplicationController
         durations = @get_ingest_duration_rows.map(&:ingest_duration)
         @avg = CsvRow.where(csv_import_id: @csv_import.id).average(:ingest_duration)
         sd = Math.sqrt(durations.sum { |x| (x - @avg)**2 } / @get_ingest_duration_rows.size)
-        sd.round(3)
+        sd.round(2)
       end
     end
 end

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -10,6 +10,11 @@ class CsvImportsController < ApplicationController
 
   def show
     @csv_rows = CsvRow.where(csv_import_id: @csv_import.id)
+    @min_ingest_duration = min
+    @max_ingest_duration = max
+    @mean_ingest_duration = mean
+    @median_ingest_duration = median
+    @standard_deviation_ingest_duration = std_deviation
   end
 
   def new; end
@@ -60,5 +65,50 @@ class CsvImportsController < ApplicationController
       return unless params['csv_import']
       @csv_import.manifest_cache = params['csv_import']['manifest_cache']
       @csv_import.record_count = params['csv_import']['record_count']
+    end
+
+    def row_times
+      @row_times ||= @csv_rows.select('ingest_duration')
+    end
+
+    def min
+      if @csv_rows.count == @csv_import.record_count
+        @min_ingest_duration = row_times.minimum(:ingest_duration)
+        @min_ingest_duration.round(3)
+      end
+    end
+
+    def max
+      if @csv_rows.count == @csv_import.record_count
+        @max_ingest_duration = row_times.maximum(:ingest_duration)
+        @max_ingest_duration.round(3)
+      end
+    end
+
+    def mean
+      if @csv_rows.count == @csv_import.record_count
+        @mean_ingest_duration = row_times.average(:ingest_duration)
+        @mean_ingest_duration.round(3)
+      end
+    end
+
+    def median
+      if @csv_rows.count == @csv_import.record_count
+        @get_ingest_duration_rows = row_times
+        durations = @get_ingest_duration_rows.map(&:ingest_duration)
+        sorted = durations.compact.sort
+        len = sorted.length
+        ((sorted[(len - 1) / 2] + sorted[len / 2]) / 2.0).round(3) if len.positive?
+      end
+    end
+
+    def std_deviation
+      if @csv_rows.count == @csv_import.record_count
+        @get_ingest_duration_rows = row_times
+        durations = @get_ingest_duration_rows.map(&:ingest_duration)
+        @avg = CsvRow.where(csv_import_id: @csv_import.id).average(:ingest_duration)
+        sd = Math.sqrt(durations.sum { |x| (x - @avg)**2 } / @get_ingest_duration_rows.size)
+        sd.round(3)
+      end
     end
 end

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -10,7 +10,7 @@
 <div class="panel-body">
   <div class="ingest-metrics-table">
     <div class="i-m-table">
-    <h4>Full import times<small class='ingest-small'> (in seconds)</small> for  <%= @csv_import.record_count %> records</h4>
+    <h4>Full CSV import metrics (<%= @csv_import.record_count %> records)</h4>
     <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
       <thead>
         <tr role='row'>
@@ -18,10 +18,10 @@
             Start time
           </th>
           <th>
-            Total record import time
+            Total elapsed time
           </th>
           <th>
-            Average import time per record
+            Average time per record
           </th>
         </tr>
       </thead>
@@ -32,14 +32,14 @@
             <% if @csv_import.elapsed_time == nil %>
               <span class='ingest-md-gray'>waiting for ingest to finish</span>
             <% else %>
-              <%= @csv_import.elapsed_time.round(3) %> seconds
+              <%= @csv_import.elapsed_time.round(2) %> seconds
             <% end %>
           </td>
           <td>
             <% if @csv_import.elapsed_time_per_record == nil %>
               <span class='ingest-md-gray'>waiting for ingest to finish</span>
             <% else %>
-              <%= @csv_import.elapsed_time_per_record.round(3) %> seconds
+              <%= @csv_import.elapsed_time_per_record.round(2) %> seconds
             <% end %>
           </td>
         </tr>
@@ -48,7 +48,8 @@
 
     <br/>
 
-    <h4>Ingest duration metrics per item<small class='ingest-small'> (in seconds)</small> for <%= @csv_import.record_count %> records</h4>
+    <h4>Row ingest metrics (<%= @csv_import.record_count %> records)</h4>
+      (Not including reindexing & manifest creation).
 
     <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
       <thead>
@@ -60,7 +61,7 @@
             Maximum
           </th>
           <th>
-            Mean (Average)
+            Mean
           </th>
           <th>
             Median

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -1,80 +1,139 @@
 <p id="notice"><%= notice %></p>
-<div class="col-xs-12 main-header">
-  <h2>CSV Import <%= @csv_import.id %></h2>
-</div>
+<h2>CSV Import <%= @csv_import.id %> <small class='ingest-small'>| <%= File.basename(@csv_import.manifest.to_s) %></small> <small class='ingest-small'> | <%= @csv_import.record_count %> queued records | <a href="/csv_imports/<%= @csv_import.id %>/log"> Ingest Log</a></small></h2>
+<h3>Current row count: <%= @csv_rows.count %> | Total record count: <%= @csv_import.record_count %></h3>
+<h4 class='ingest-gray'>(Refresh page to view updated ingest)</h4>
+<p>
+  <span class='ingest-md-gray'><label> Uploaded by: </label></span>
+  <span> <%= @csv_import.user.name %> </span>
+</p>
+
 <div class="panel-body">
-  <p>
-    <label> CSV Manifest: </label>
-    <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
-    <br />
-    <span style="color: gray"><label> Uploaded by: </label></span>
-    <span> <%= @csv_import.user.name %> </span>
-    <br />
-    <label> Start time: </label>
-    <span> <%= @csv_import.created_at.strftime('%e %b %Y %l:%M %p') %> </span>
-    <br />
-    <label> Total record import time: </label>
-    <span>
-      <% if @csv_import.elapsed_time == nil %>
-        <span class="calculating">Calculating...</span>
-      <% else %>
-        <%= @csv_import.elapsed_time.round(3) %> seconds
-      <% end %>
-    </span>
-    <br />
-    <label> Average import time per record: </label>
-    <span>
-      <% if @csv_import.elapsed_time_per_record == nil %>
-        <span class="calculating">Calculating...</span>
-      <% else %>
-        <%= @csv_import.elapsed_time_per_record.round(3) %> seconds
-      <% end %>
-    </span>
-    <br />
-    <label> Queued records: </label>
-    <span> <%= @csv_import.record_count %> </span>
-    <br />
-    <label> Logs: </label>
-    <span> <a href="/csv_imports/<%= @csv_import.id %>/log">Ingest Log</a> </span>
-  </p>
-  <table class="table-condensed table-striped datatable dataTable no-footer" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
-    <thead>
-      <tr role="row">
-        <th class="sorting_desc">
-          Row Number
-        </th>
-        <th>
-          Item Ark
-        </th>
-        <th>
-          Last Updated
-        </th>
-        <th>
-          Error message(s)
-        </th>
-        <th>
-          Status
-        </th>
-        <th>
-          Ingest Duration (in seconds)
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @csv_rows.each do |csv_row| %>
-        <tr>
-          <td><%= csv_row.row_number || "Unknown" %></td>
-          <td><%= JSON.parse(csv_row.metadata)["Item ARK"] || "Unknown" %></td>
-          <td><%= csv_row.updated_at.strftime('%e %b %Y %l:%M %p') || "Unknown" %></td>
-          <td><%= csv_row.error_messages || "" %></td>
-          <td><%= csv_row.status || "Unknown" %></td>
-          <% if csv_row.ingest_duration == nil %>
-            <td>Unknown</td>
-          <% else %>
-          <td><%= csv_row.ingest_duration.round(3) || "Unknown" %></td>
-          <% end %>
+  <div class="ingest-metrics-table">
+    <div class="i-m-table">
+    <h4>Full import times<small class='ingest-small'> (in seconds)</small> for  <%= @csv_import.record_count %> records</h4>
+    <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
+      <thead>
+        <tr role='row'>
+          <th>
+            Start time
+          </th>
+          <th>
+            Total record import time
+          </th>
+          <th>
+            Average import time per record
+          </th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <tr>
+          <td><%= @csv_import.created_at.strftime('%e %b %Y %l:%M %p') %></td>
+          <td>
+            <% if @csv_import.elapsed_time == nil %>
+              <span class='ingest-md-gray'>waiting for ingest to finish</span>
+            <% else %>
+              <%= @csv_import.elapsed_time.round(3) %> seconds
+            <% end %>
+          </td>
+          <td>
+            <% if @csv_import.elapsed_time_per_record == nil %>
+              <span class='ingest-md-gray'>waiting for ingest to finish</span>
+            <% else %>
+              <%= @csv_import.elapsed_time_per_record.round(3) %> seconds
+            <% end %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <br/>
+
+    <h4>Ingest duration metrics per item<small class='ingest-small'> (in seconds)</small> for <%= @csv_import.record_count %> records</h4>
+
+    <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
+      <thead>
+        <tr role="row">
+          <th>
+            Minimum
+          </th>
+          <th>
+            Maximum
+          </th>
+          <th>
+            Mean (Average)
+          </th>
+          <th>
+            Median
+          </th>
+          <th>
+            Standard deviation
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <% if @csv_rows.count != @csv_import.record_count %>
+         <tr>
+          <td colspan='5' class='ingest-md-gray'>Metrics will display after all records have been ingested.</td>
+        </tr>
+      <% else %>
+        <tr>
+          <td>
+            <%= @min_ingest_duration %><br/></td>
+          <td>
+            <%= @max_ingest_duration || nil %></td>
+          <td>
+            <%= @mean_ingest_duration || nil %></td>
+          <td>
+            <%= @median_ingest_duration || nil %></td>
+          <td>
+            <%= @standard_deviation_ingest_duration || nil %></td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>
+<br/>
+
+<hr class='ingest-hr'>
+<table class="table-condensed table-striped datatable dataTable no-footer 
+v_logs ingest-metrics" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
+  <thead>
+    <tr role="row">
+      <th class="sorting_desc">
+        Row&nbsp;#
+      </th>
+      <th>
+        Item Ark
+      </th>
+      <th>
+        Last Updated
+      </th>
+      <th>
+        Ingest Duration (in seconds)
+      </th>
+      <th>
+        Status
+      </th>
+      <th>
+        Error message(s)
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @csv_rows.each do |csv_row| %>
+      <tr>
+        <td><%= csv_row.row_number || "Unknown" %></td>
+        <td><%= JSON.parse(csv_row.metadata)["Item ARK"] || "Unknown" %></td>
+        <td><%= csv_row.updated_at.strftime('%e %b %Y %l:%M %p') || "Unknown" %></td>
+        <% if csv_row.ingest_duration == nil %>
+          <td>Unknown</td>
+        <% else %>
+          <td style='text-align: center'><%= csv_row.ingest_duration.round(3) || "Unknown" %></td>
+        <% end %>
+        <td><%= csv_row.status || "Unknown" %></td>
+        <td><%= csv_row.error_messages || "" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/spec/system/csv_import_status_show_spec.rb
+++ b/spec/system/csv_import_status_show_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
       expect(page).to have_content 'Mean'
       expect(page).to have_content 'Median'
       expect(page).to have_content 'Standard deviation'
-      expect(page).to have_content 0.869 # min
-      expect(page).to have_content 2.181 # max
-      expect(page).to have_content 1.363 # mean/average 1.363
-      expect(page).to have_content 1.039 # median
-      expect(page).to have_content 0.583 # std_deviation
+      expect(page).to have_content 0.87 # min
+      expect(page).to have_content 2.18 # max
+      expect(page).to have_content 1.36 # mean/average 1.36
+      expect(page).to have_content 1.04 # median
+      expect(page).to have_content 0.58 # std_deviation
     end
   end
 end

--- a/spec/system/csv_import_status_show_spec.rb
+++ b/spec/system/csv_import_status_show_spec.rb
@@ -5,24 +5,39 @@ include Warden::Test::Helpers
 RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
   context 'logged in as an admin user' do
     let(:admin_user) { FactoryBot.create(:admin) }
-    let(:csv_import) { FactoryBot.create(:csv_import, record_count: 52) }
-    let(:csv_row1) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id) }
-    let(:csv_row2) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id) }
+    let(:csv_import) { FactoryBot.create(:csv_import, record_count: 3) }
+    let(:csv_row1) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, ingest_duration: 0.869) }
+    let(:csv_row2) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, ingest_duration: 2.181) }
+    let(:csv_row3) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, ingest_duration: 1.039) }
 
     before do
       login_as admin_user
       csv_import
       csv_row1
       csv_row2
+      csv_row3
     end
 
     it 'starts the import' do
       visit "/csv_imports/#{csv_import.id}"
       expect(page).to have_content csv_import.id
       expect(page).to have_content csv_import.created_at.strftime('%e %b %Y %l:%M %p')
-      expect(page).to have_content "complete"
-      expect(page).to have_content "52"
-      expect(page).to have_content "here is your error"
+      expect(page).to have_content 'complete'
+      expect(page).to have_content '3'
+      expect(page).to have_content 'here is your error'
+      expect(page).to have_content 'Current row count'
+      expect(page).to have_content '(Refresh page to view updated ingest)'
+      expect(page).to_not have_content 'Puppy'
+      expect(page).to have_content 'Minimum'
+      expect(page).to have_content 'Maximum'
+      expect(page).to have_content 'Mean'
+      expect(page).to have_content 'Median'
+      expect(page).to have_content 'Standard deviation'
+      expect(page).to have_content 0.869 # min
+      expect(page).to have_content 2.181 # max
+      expect(page).to have_content 1.363 # mean/average 1.363
+      expect(page).to have_content 1.039 # median
+      expect(page).to have_content 0.583 # std_deviation
     end
   end
 end

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
       csv_import = CsvImport.last
 
       expect(page).to have_content("CSV Import #{csv_import.id}")
-      expect(page).to have_content("Total record import time")
-      expect(page).to have_content("Average import time per record")
+      expect(page).to have_content("Full CSV import metrics")
+      expect(page).to have_content("Row ingest metrics")
       expect(csv_import.record_count).to eq 2
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
       expect(page).to have_content("Ingest Duration (in seconds)")


### PR DESCRIPTION
Connected to [CAL-753](https://jira.library.ucla.edu/browse/CAL-753)

### Display ingest metrics on CSV Import Show Page

#### CSV Ingest Show Page calculates and displays the following metrics based on the ingest duration time:
+ min
+ max
+ mean
+ median
+ standard deviation

<img width="1321" alt="Screen Shot 2019-09-06 at 11 28 11 AM" src="https://user-images.githubusercontent.com/751697/64459719-6ee60a00-d0ad-11e9-9006-2793d29ee9a7.png">

<img width="1266" alt="Screen Shot 2019-09-06 at 10 18 18 AM" src="https://user-images.githubusercontent.com/751697/64459733-760d1800-d0ad-11e9-90a6-7d9254e85aa7.png">

---

Changes to be committed:
+ new file:   app/assets/stylesheets/_ingest_metrics.scss
+ modified:   app/assets/stylesheets/_variables.scss
+ modified:   app/assets/stylesheets/application.css
+ modified:   app/assets/stylesheets/hyrax.scss
+ modified:   app/controllers/csv_imports_controller.rb
+ modified:   app/views/csv_imports/show.html.erb
+ modified:   spec/system/csv_import_status_show_spec.rb