### PR TITLE
Wrap manifest creation in job

### DIFF
--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateManifestJob < ApplicationJob
+  queue_as :default
+
+  def perform(work_ark)
+    work = ActiveFedora::Base.where(ark: work_ark)
+    Californica::ManifestBuilderService.new(curation_concern: work).persist
+  end
+end

--- a/spec/jobs/create_manifest_job_spec.rb
+++ b/spec/jobs/create_manifest_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CreateManifestJob, :clean do
+  let(:work) { FactoryBot.build_stubbed(:work) }
+  let(:service) { Californica::ManifestBuilderService.new(curation_concern: work) }
+
+  before do
+    allow(Californica::ManifestBuilderService).to receive(:new).with(curation_concern: work).and_return(service)
+    allow(ActiveFedora::Base).to receive(:where).with(ark: work.ark).and_return(work)
+  end
+
+  it 'calls the ManifestBuilderService' do
+    allow(service).to receive(:persist)
+    CreateManifestJob.perform_now(work.ark)
+    expect(service).to have_received(:persist)
+  end
+end


### PR DESCRIPTION
Right now it's executed synchronously with "perform_now" so that its timing will be tracked as part of the parent job. In the future it will be executed asynchronously.