### PR TITLE
add spring-commands-rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'simplecov', '~> 0.16.1'
   gem 'solr_wrapper', '>= 0.3'
+  gem 'spring-commands-rspec'
   gem 'webmock'
   gem 'xray-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -796,6 +796,8 @@ GEM
       net-http-persistent (>= 2.9, < 4)
       rdf (~> 3.0)
     spring (2.1.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -912,6 +914,7 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
   solr_wrapper (>= 0.3)
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
this enables the rspec suite to use the spring preloader, which is already being used by the development server.

Turns this:
```
californica$ bundle exec rspec spec/jobs/create_manifest_job_spec.rb

Randomized with seed 21165

CreateManifestJob
  calls the ManifestBuilderService

Top 1 slowest examples (0.30446 seconds, 75.1% of total time):
  CreateManifestJob calls the ManifestBuilderService
    0.30446 seconds ./spec/jobs/create_manifest_job_spec.rb:13

Finished in 0.40524 seconds (files took 21.49 seconds to load)
1 example, 0 failures

Randomized with seed 21165
```

Into this:
```
californica$ bundle exec spring rspec spec/jobs/create_manifest_job_spec.rb
Running via Spring preloader in process 77178

Randomized with seed 39080

CreateManifestJob
  calls the ManifestBuilderService

Top 1 slowest examples (0.34239 seconds, 73.1% of total time):
  CreateManifestJob calls the ManifestBuilderService
    0.34239 seconds ./spec/jobs/create_manifest_job_spec.rb:13

Finished in 0.46841 seconds (files took 0.94632 seconds to load)
1 example, 0 failures

Randomized with seed 39080
```