### PR TITLE
CAL-792 Find objects with "find" not "where"

### DIFF
--- a/app/models/child_work.rb
+++ b/app/models/child_work.rb
@@ -13,7 +13,9 @@ class ChildWork < ActiveFedora::Base
   # @param ark [String] The ARK
   # @return [Work] The Work with that ARK
   def self.find_by_ark(ark)
-    where(ark_ssi: ark).limit(1).first
+    find(Californica::IdGenerator.id_from_ark(ark))
+  rescue ActiveFedora::ObjectNotFoundError
+    nil
   end
 
   # This must be included at the end, because it finalizes the metadata

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -18,7 +18,9 @@ class Collection < ActiveFedora::Base
   # @param ark [String] The ARK
   # @return [Collection] The Collection with that ARK
   def self.find_by_ark(ark)
-    where(ark_ssi: ark).limit(1).first
+    find(Californica::IdGenerator.id_from_ark(ark))
+  rescue ActiveFedora::ObjectNotFoundError
+    nil
   end
 
   # Do not recalculate size unless recalculate_size == true

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -18,7 +18,9 @@ class Work < ActiveFedora::Base
   # @param ark [String] The ARK
   # @return [Work] The Work with that ARK
   def self.find_by_ark(ark)
-    where(ark_ssi: ark).limit(1).first
+    find(Californica::IdGenerator.id_from_ark(ark))
+  rescue ActiveFedora::ObjectNotFoundError
+    nil
   end
 
   # @param ark [String] The ARK


### PR DESCRIPTION
Since find queries fedora rather than solr, this is necessary to find objects that have been created but never indexed, as when indexing is deferred during ingest.