### PR TITLE
Allow deduplicated jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,5 +6,27 @@ class ApplicationJob < ActiveJob::Base
 
   before_perform do |job|
     job.jid = job.provider_job_id
+    redis = Redis.current
+    redis.set(redis_key, 'false')
+  end
+
+  around_enqueue do |_, block|
+    if deduplication_key
+      redis = Redis.current
+      unless redis.get(redis_key) == 'true'
+        redis.set(redis_key, 'true')
+        block.call
+      end
+    else
+      block.call
+    end
+  end
+
+  def deduplication_key
+    nil
+  end
+
+  def redis_key
+    (@redis_key ||= "in_queue_#{deduplication_key}") if deduplication_key
   end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+class TestJob < ApplicationJob
+  def perform; end
+end
+
+class DeduplicatedJob < TestJob
+  def deduplication_key
+    'abc123'
+  end
+end
+
+RSpec.describe ApplicationJob, type: :job do
+  after { Redis.current.del('in_queue_abc123') }
+
+  describe '#perform_later' do
+    context 'when #deduplication_key is not set' do
+      it 'always enqueues the job' do
+        expect do
+          TestJob.perform_later
+          TestJob.perform_later
+        end.to have_enqueued_job(TestJob).exactly(:twice)
+      end
+    end
+
+    context 'when #deduplication_key is set on a subclass' do
+      it 'only enqueues the job if it\'s not in the queue already' do
+        expect do
+          DeduplicatedJob.perform_later
+          DeduplicatedJob.perform_later
+          DeduplicatedJob.perform_now
+        end.to have_enqueued_job(DeduplicatedJob).exactly(:once)
+      end
+
+      it 'allows a job to be enqueued again after it has run' do
+        expect do
+          DeduplicatedJob.perform_later
+          DeduplicatedJob.perform_now
+          DeduplicatedJob.perform_later
+        end.to have_enqueued_job(DeduplicatedJob).exactly(:twice)
+      end
+    end
+  end
+
+  describe '#deduplication_key' do
+    it 'returns nil by default' do
+      expect(TestJob.new.deduplication_key).to be_nil
+    end
+  end
+
+  describe '#redis_key' do
+    context 'when #deduplication_key is not set' do
+      it 'is nil' do
+        expect(TestJob.new.redis_key).to be_nil
+      end
+    end
+
+    context 'when #deduplication_key is set on a subclass' do
+      before { allow_any_instance_of(TestJob).to receive(:deduplication_key).and_return('abc123') }
+
+      it 'is based on #deduplication_key' do
+        expect(TestJob.new.redis_key).to eq 'in_queue_abc123'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds infrastructure to ApplicationJob such that its subclasses may define a method 'deduplication_key', with the result that if a job has already been enqueued with the same deduplication_key, it will not be enqueued again.