### PR TITLE
Support for re-parallelizing ingest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,11 +53,12 @@ Metrics/ModuleLength:
 Metrics/CyclomaticComplexity:
   Enabled: true
   Exclude:
-    - app/uploaders/csv_manifest_validator.rb
     - app/importers/actor_record_importer.rb
     - app/importers/californica_csv_parser.rb
-    - app/models/concerns/discoverable.rb
     - app/indexers/collection_indexer.rb
+    - app/jobs/reindex_item_job.rb
+    - app/models/concerns/discoverable.rb
+    - app/uploaders/csv_manifest_validator.rb
 
 Metrics/LineLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,22 +107,23 @@ RSpec/AnyInstance:
 RSpec/ExampleLength:
   Enabled: true
   Exclude:
-    - 'spec/forms/hyrax/child_work_form_spec.rb'
-    - 'spec/forms/hyrax/work_form_spec.rb'
-    - 'spec/importers/californica_importer_spec.rb'
-    - 'spec/importers/californica_mapper_spec.rb'
-    - 'spec/importers/collection_record_importer_spec.rb'
-    - 'spec/jobs/inherit_permissions_job_spec.rb'
-    - 'spec/jobs/mss_csv_import_job_spec.rb'
-    - 'spec/jobs/mss_csv_import_job_spec.rb'
-    - 'spec/jobs/start_csv_import_job_spec.rb'
-    - 'spec/jobs/start_csv_import_job_spec.rb'
-    - 'spec/models/concerns/discoverable_spec.rb'
-    - 'spec/system**/*'
-    - 'spec/tasks/ingest_spec.rb'
-    - 'spec/uploaders/csv_manifest_validator_spec.rb'
-    - 'spec/views**/*'
-    - 'spec/views/manifest.json.jbuilder_spec.rb'
+    - spec/forms/hyrax/child_work_form_spec.rb
+    - spec/forms/hyrax/work_form_spec.rb
+    - spec/importers/californica_importer_spec.rb
+    - spec/importers/californica_mapper_spec.rb
+    - spec/importers/collection_record_importer_spec.rb
+    - spec/jobs/inherit_permissions_job_spec.rb
+    - spec/jobs/mss_csv_import_job_spec.rb
+    - spec/jobs/mss_csv_import_job_spec.rb
+    - spec/jobs/reindex_item_job_spec.rb
+    - spec/jobs/start_csv_import_job_spec.rb
+    - spec/jobs/start_csv_import_job_spec.rb
+    - spec/models/concerns/discoverable_spec.rb
+    - spec/system**/*
+    - spec/tasks/ingest_spec.rb
+    - spec/uploaders/csv_manifest_validator_spec.rb
+    - spec/views**/*
+    - spec/views/manifest.json.jbuilder_spec.rb
 
 RSpec/LetSetup:
   Enabled: false

--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -14,6 +14,10 @@ class CreateManifestJob < ApplicationJob
     log_end(csv_import_task_id)
   end
 
+  def deduplication_key
+    "CreateManifestJob-#{arguments[0]}"
+  end
+
   private
 
     def log_start(csv_import_task_id)

--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -3,9 +3,40 @@
 class CreateManifestJob < ApplicationJob
   queue_as :default
 
-  def perform(work_ark)
+  def perform(work_ark, csv_import_task_id: nil)
+    log_start(csv_import_task_id)
+
     work = Work.find_by_ark(work_ark) || ChildWork.find_by_ark(work_ark)
     raise(ArgumentError, "No such Work or ChildWork: #{work_ark}.") unless work
+
     Californica::ManifestBuilderService.new(curation_concern: work).persist
+
+    log_end(csv_import_task_id)
   end
+
+  private
+
+    def log_start(csv_import_task_id)
+      return unless csv_import_task_id
+      @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      csv_import_task = CsvImportTask.find(csv_import_task_id)
+      csv_import_task.job_status = 'In Progress'
+      begin
+        csv_import_task.times_started += 1
+      rescue NoMethodError
+        csv_import_task = 0
+      end
+      csv_import_task.start_timestamp = @start_time
+      csv_import_task.save
+    end
+
+    def log_end(csv_import_task_id)
+      return unless csv_import_task_id
+      csv_import_task = CsvImportTask.find(csv_import_task_id)
+      @end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      csv_import_task.end_timestamp = @end_time
+      csv_import_task.job_duration = @end_time - @start_time
+      csv_import_task.job_status = 'Complete'
+      csv_import_task.save
+    end
 end

--- a/app/jobs/reindex_item_job.rb
+++ b/app/jobs/reindex_item_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ReindexItemJob < ApplicationJob
+  queue_as :default
+
+  def perform(item_ark, csv_import_id: nil)
+    item = Collection.find_by_ark(item_ark) || Work.find_by_ark(item_ark) || ChildWork.find_by_ark(item_ark)
+    raise(ArgumentError, "No such item: #{item_ark}.") unless item
+    set_recalculate_size(item)
+    item.save
+  end
+
+  def deduplication_key
+    "ReindexItemJob-#{arguments[0]}"
+  end
+
+  def set_recalculate_size(item)
+    item.recalculate_size = true
+  rescue NoMethodError
+    nil
+  end
+
+end

--- a/app/jobs/reindex_item_job.rb
+++ b/app/jobs/reindex_item_job.rb
@@ -3,12 +3,14 @@
 class ReindexItemJob < ApplicationJob
   queue_as :default
 
-  def perform(item_ark, csv_import_id: nil)
+  def perform(item_ark, csv_import_task_id: nil)
+    log_start(csv_import_task_id)
+
     item = Collection.find_by_ark(item_ark) || Work.find_by_ark(item_ark) || ChildWork.find_by_ark(item_ark)
     raise(ArgumentError, "No such item: #{item_ark}.") unless item
 
     # Apply page orderings if importing Works from a CSV
-    if csv_import_id && item.is_a?(Work)
+    if csv_import_task_id && item.is_a?(Work)
       page_orderings = PageOrder.where(parent: Ark.ensure_prefix(item_ark))
       ordered_arks = page_orderings.sort_by(&:sequence)
       item.ordered_members = ordered_arks.map { |b| ChildWork.find_by_ark(b.child) }
@@ -18,15 +20,43 @@ class ReindexItemJob < ApplicationJob
     item.save
 
     CreateManifestJob.perform_later(item_ark) unless item.is_a? Collection
+
+    log_end(csv_import_task_id)
   end
 
   def deduplication_key
     "ReindexItemJob-#{arguments[0]}"
   end
 
-  def enable_recalculate_size(item)
-    item.recalculate_size = true
-  rescue NoMethodError
-    nil
-  end
+  private
+
+    def log_start(csv_import_task_id)
+      return unless csv_import_task_id
+      @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      csv_import_task = CsvImportTask.find(csv_import_task_id)
+      csv_import_task.job_status = 'In Progress'
+      begin
+        csv_import_task.times_started += 1
+      rescue NoMethodError
+        csv_import_task = 0
+      end
+      csv_import_task.start_timestamp = @start_time
+      csv_import_task.save
+    end
+
+    def log_end(csv_import_task_id)
+      return unless csv_import_task_id
+      csv_import_task = CsvImportTask.find(csv_import_task_id)
+      @end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      csv_import_task.end_timestamp = @end_time
+      csv_import_task.job_duration = @end_time - @start_time
+      csv_import_task.job_status = 'Complete'
+      csv_import_task.save
+    end
+
+    def enable_recalculate_size(item)
+      item.recalculate_size = true
+    rescue NoMethodError
+      nil
+    end
 end

--- a/app/jobs/reindex_item_job.rb
+++ b/app/jobs/reindex_item_job.rb
@@ -6,18 +6,27 @@ class ReindexItemJob < ApplicationJob
   def perform(item_ark, csv_import_id: nil)
     item = Collection.find_by_ark(item_ark) || Work.find_by_ark(item_ark) || ChildWork.find_by_ark(item_ark)
     raise(ArgumentError, "No such item: #{item_ark}.") unless item
-    set_recalculate_size(item)
+
+    # Apply page orderings if importing Works from a CSV
+    if csv_import_id && item.is_a?(Work)
+      page_orderings = PageOrder.where(parent: Ark.ensure_prefix(item_ark))
+      ordered_arks = page_orderings.sort_by(&:sequence)
+      item.ordered_members = ordered_arks.map { |b| ChildWork.find_by_ark(b.child) }
+    end
+
+    enable_recalculate_size(item)
     item.save
+
+    CreateManifestJob.perform_later(item_ark) unless item.is_a? Collection
   end
 
   def deduplication_key
     "ReindexItemJob-#{arguments[0]}"
   end
 
-  def set_recalculate_size(item)
+  def enable_recalculate_size(item)
     item.recalculate_size = true
   rescue NoMethodError
     nil
   end
-
 end

--- a/app/models/csv_import_task.rb
+++ b/app/models/csv_import_task.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CsvImportTask < ApplicationRecord
+  belongs_to :csv_import
+end

--- a/db/migrate/20191011173814_create_csv_import_tasks.rb
+++ b/db/migrate/20191011173814_create_csv_import_tasks.rb
@@ -1,0 +1,17 @@
+class CreateCsvImportTasks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :csv_import_tasks do |t|
+      t.references :csv_import, foreign_key: true
+      t.string :job_status
+      t.string :job_type
+      t.string :item_ark
+      t.string :object_type
+      t.float :job_duration
+      t.integer :times_started
+      t.timestamp :start_timestamp
+      t.timestamp :end_timestamp
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191009185051) do
+ActiveRecord::Schema.define(version: 20191011173814) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -65,6 +65,21 @@ ActiveRecord::Schema.define(version: 20191009185051) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "external_key"
+  end
+
+  create_table "csv_import_tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "csv_import_id"
+    t.string "job_status"
+    t.string "job_type"
+    t.string "item_ark"
+    t.string "object_type"
+    t.float "job_duration", limit: 24
+    t.integer "times_started"
+    t.timestamp "start_timestamp"
+    t.timestamp "end_timestamp"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["csv_import_id"], name: "index_csv_import_tasks_on_csv_import_id"
   end
 
   create_table "csv_imports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -605,6 +620,7 @@ ActiveRecord::Schema.define(version: 20191009185051) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "csv_import_tasks", "csv_imports"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
   add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
   add_foreign_key "permission_template_accesses", "permission_templates"

--- a/default.env
+++ b/default.env
@@ -34,7 +34,7 @@ REDIS_PORT=6379
 REDIS_URL=redis://localhost:6379/0
 SIDEKIQ_WORKERS=7
 SOLR_TEST_URL=http://localhost:8985/solr/californica
-SOLR_URL=http://solr:8983/solr/californica
+SOLR_URL=http://localhost:8983/solr/californica
 
 
 # The following variables are passed to the browser as is. Therefore, they should use the URLs to which the services map on the host, not the URLs used within docker containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,12 @@ services:
     volumes:
       - .:/californica
       - ./data:/opt/data
-      - derivatives:/opt/derivatives
-      - uploads:/opt/uploads
       - bundle_dir:/usr/local/bundle
       - californica_tmp:/californica/tmp
+      - derivatives:/opt/derivatives
+      - californica_log:/californica/log
       - tmp:/tmp
+      - uploads:/opt/uploads
     working_dir: /californica
 
   sidekiq:
@@ -43,11 +44,12 @@ services:
     volumes:
       - .:/californica
       - ./data:/opt/data
-      - derivatives:/opt/derivatives
-      - uploads:/opt/uploads
       - bundle_dir:/usr/local/bundle
+      - californica_log:/californica/log
       - californica_tmp:/californica/tmp
+      - derivatives:/opt/derivatives
       - tmp:/tmp
+      - uploads:/opt/uploads
     working_dir: /californica
 
   fedora:
@@ -114,11 +116,12 @@ services:
 
 volumes:
   bundle_dir:
+  californica_log:
+  californica_tmp:
   derivatives:
   fcrepo_data:
   mysql_data:
   redis_data:
   solr_data:
   tmp:
-  californica_tmp:
   uploads:

--- a/spec/actors/californica/manifest_actor_spec.rb
+++ b/spec/actors/californica/manifest_actor_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe Californica::ManifestActor do
   let(:next_actor) { instance_double('Hyrax::Actors::BaseActor', create: true, update: true, destroy: true) }
   let(:work) { FactoryBot.build(:work, attrs) }
 
-  before { ActiveJob::Base.queue_adapter = :test }
+  before do
+    Redis.current.flushall
+    ActiveJob::Base.queue_adapter = :test
+  end
 
   describe '#create' do
     before { actor.create(env) }

--- a/spec/factories/csv_import_tasks.rb
+++ b/spec/factories/csv_import_tasks.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :csv_import_task do
+    csv_import { nil }
+    job_status { "MyString" }
+    job_type { "MyString" }
+    item_ark { "MyString" }
+    object_type { "MyString" }
+    job_duration { 1.5 }
+    times_started { 1 }
+    start_timestamp { "2019-10-11 10:38:15" }
+    end_timestamp { "2019-10-11 10:38:15" }
+  end
+end

--- a/spec/jobs/create_manifest_job_spec.rb
+++ b/spec/jobs/create_manifest_job_spec.rb
@@ -15,4 +15,19 @@ RSpec.describe CreateManifestJob, :clean do
     CreateManifestJob.perform_now(work.ark)
     expect(service).to have_received(:persist)
   end
+
+  context 'when it gets a CsvImportTask object' do
+    let(:csv_import_task) do
+      csv_import_task = FactoryBot.build(:csv_import_task, id: 123, job_duration: nil)
+      allow(CsvImportTask).to receive(:find).with(csv_import_task.id).and_return(csv_import_task)
+      csv_import_task
+    end
+
+    before { allow_any_instance_of(Californica::ManifestBuilderService).to receive(:persist) }
+
+    it 'logs the duration to that object' do
+      described_class.perform_now(work.ark, csv_import_task_id: csv_import_task.id)
+      expect(csv_import_task.job_duration).not_to be_nil
+    end
+  end
 end

--- a/spec/jobs/reindex_item_job_spec.rb
+++ b/spec/jobs/reindex_item_job_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe ReindexItemJob, type: :job do
 
   it 'gets deduplicated' do
     allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item)
-    described_class.perform_now(item.ark)
     expect do
       described_class.perform_later(item.ark)
       described_class.perform_later(item.ark)

--- a/spec/jobs/reindex_item_job_spec.rb
+++ b/spec/jobs/reindex_item_job_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe ReindexItemJob, type: :job do
       let(:child1) { FactoryBot.build(:child_work) }
       let(:child2) { FactoryBot.build(:child_work) }
       let(:child3) { FactoryBot.build(:child_work) }
+      let(:csv_import_task) { FactoryBot.build(:csv_import_task, id: 123) }
       let(:page_order_objects) do
         [PageOrder.new(parent: item.ark, child: child2.ark, sequence: 2),
          PageOrder.new(parent: item.ark, child: child1.ark, sequence: 1),
@@ -68,11 +69,11 @@ RSpec.describe ReindexItemJob, type: :job do
         allow(ChildWork).to receive(:find_by_ark).with(child1.ark).and_return(child1)
         allow(ChildWork).to receive(:find_by_ark).with(child2.ark).and_return(child2)
         allow(ChildWork).to receive(:find_by_ark).with(child3.ark).and_return(child3)
-        # allow(item).to receive(:save).and_call_original
+        allow(CsvImportTask).to receive(:find).with(csv_import_task.id).and_return(csv_import_task)
       end
 
       it 'applies the page order' do
-        described_class.perform_now(item.ark, csv_import_id: 123)
+        described_class.perform_now(item.ark, csv_import_task_id: csv_import_task.id)
         expect(item.ordered_member_ids).to eq [child1.id, child2.id, child3.id]
       end
     end
@@ -94,9 +95,22 @@ RSpec.describe ReindexItemJob, type: :job do
     end
   end
 
-  context 'when it gets a CsvImport object' do
-    let(:csv_import) { FactoryBot.build(:csv_import) }
+  context 'when it gets a CsvImportTask object' do
+    let(:csv_import_task) do
+      csv_import_task = FactoryBot.build(:csv_import_task, id: 123, job_duration: nil)
+      allow(CsvImportTask).to receive(:find).with(csv_import_task.id).and_return(csv_import_task)
+      csv_import_task
+    end
 
-    it 'logs the time to that object'
+    let(:item) do
+      item = FactoryBot.build(:work)
+      allow(Work).to receive(:find_by_ark).with(item.ark).and_return(item)
+      item
+    end
+
+    it 'logs the duration to that object' do
+      described_class.perform_now(item.ark, csv_import_task_id: csv_import_task.id)
+      expect(csv_import_task.job_duration).not_to be_nil
+    end
   end
 end

--- a/spec/jobs/reindex_item_job_spec.rb
+++ b/spec/jobs/reindex_item_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ReindexItemJob, type: :job do
+  let(:item) { FactoryBot.build_stubbed(:collection) }
+
+  before do
+    allow(item).to receive(:save)
+  end
+  
+  it 'sets recalculate_size=true' do
+    allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item)
+    described_class.perform_now(item.ark)
+    expect(item.recalculate_size).to be true
+  end
+  
+  it 'calls save to trigger a reindex' do
+    allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item)
+    described_class.perform_now(item.ark)
+    expect(item).to have_received(:save)
+  end
+
+  it 'gets deduplicated' do
+    expect do
+      described_class.perform_later(item.ark)
+      described_class.perform_later(item.ark)
+    end.to have_enqueued_job(described_class).exactly(:once)
+  end
+  
+  context 'when the item is a Work' do
+    let(:item) { FactoryBot.build(:work) }
+
+    it 'calls save to trigger a reindex' do
+      allow(Work).to receive(:find_by_ark).with(item.ark).and_return(item)
+      described_class.perform_now(item.ark)
+      expect(item).to have_received(:save)
+    end
+  end
+  
+  context 'when the item is a ChildWork' do
+    let(:item) { FactoryBot.build(:work) }
+
+    it 'calls save to trigger a reindex' do
+      allow(ChildWork).to receive(:find_by_ark).with(item.ark).and_return(item)
+      described_class.perform_now(item.ark)
+      expect(item).to have_received(:save)
+    end
+  end
+
+  context 'when it gets a CsvImport object' do
+    let(:csv_import) { FactoryBot.build(:csv_import) }
+
+    it 'logs the time to that object'
+  end
+end

--- a/spec/jobs/reindex_item_job_spec.rb
+++ b/spec/jobs/reindex_item_job_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe ReindexItemJob, type: :job do
   it 'gets deduplicated' do
     allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item)
     expect do
+      described_class.perform_now(item.ark) # to reset Redis 'in_queue' lock
       described_class.perform_later(item.ark)
       described_class.perform_later(item.ark)
     end.to have_enqueued_job(described_class).exactly(:once)

--- a/spec/jobs/reindex_item_job_spec.rb
+++ b/spec/jobs/reindex_item_job_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe ReindexItemJob, type: :job do
   before do
     allow(item).to receive(:save)
   end
-  
+
   it 'sets recalculate_size=true' do
     allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item)
     described_class.perform_now(item.ark)
     expect(item.recalculate_size).to be true
   end
-  
+
   it 'calls save to trigger a reindex' do
     allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item)
     described_class.perform_now(item.ark)
@@ -21,29 +21,77 @@ RSpec.describe ReindexItemJob, type: :job do
   end
 
   it 'gets deduplicated' do
+    allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item)
+    described_class.perform_now(item.ark)
     expect do
       described_class.perform_later(item.ark)
       described_class.perform_later(item.ark)
     end.to have_enqueued_job(described_class).exactly(:once)
   end
-  
+
+  context 'when the item is a collection' do
+    before { allow(Collection).to receive(:find_by_ark).with(item.ark).and_return(item) }
+
+    it 'does not enqueue a CreateManifestJob' do
+      expect do
+        described_class.perform_now(item.ark)
+      end.not_to have_enqueued_job(CreateManifestJob).with(item.ark)
+    end
+  end
+
   context 'when the item is a Work' do
     let(:item) { FactoryBot.build(:work) }
+    before { allow(Work).to receive(:find_by_ark).with(item.ark).and_return(item) }
 
     it 'calls save to trigger a reindex' do
-      allow(Work).to receive(:find_by_ark).with(item.ark).and_return(item)
       described_class.perform_now(item.ark)
       expect(item).to have_received(:save)
     end
+
+    it 'enqueues a CreateManifestJob' do
+      expect do
+        described_class.perform_now(item.ark)
+      end.to have_enqueued_job(CreateManifestJob).with(item.ark)
+    end
+
+    context 'when the Work has children' do
+      let(:child1) { FactoryBot.build(:child_work) }
+      let(:child2) { FactoryBot.build(:child_work) }
+      let(:child3) { FactoryBot.build(:child_work) }
+      let(:page_order_objects) do
+        [PageOrder.new(parent: item.ark, child: child2.ark, sequence: 2),
+         PageOrder.new(parent: item.ark, child: child1.ark, sequence: 1),
+         PageOrder.new(parent: item.ark, child: child3.ark, sequence: 3)]
+      end
+
+      before do
+        allow(PageOrder).to receive(:where).with(parent: item.ark).and_return(page_order_objects)
+        allow(ChildWork).to receive(:find_by_ark).with(child1.ark).and_return(child1)
+        allow(ChildWork).to receive(:find_by_ark).with(child2.ark).and_return(child2)
+        allow(ChildWork).to receive(:find_by_ark).with(child3.ark).and_return(child3)
+        # allow(item).to receive(:save).and_call_original
+      end
+
+      it 'applies the page order' do
+        described_class.perform_now(item.ark, csv_import_id: 123)
+        expect(item.ordered_member_ids).to eq [child1.id, child2.id, child3.id]
+      end
+    end
   end
-  
+
   context 'when the item is a ChildWork' do
     let(:item) { FactoryBot.build(:work) }
+    before { allow(ChildWork).to receive(:find_by_ark).with(item.ark).and_return(item) }
 
     it 'calls save to trigger a reindex' do
-      allow(ChildWork).to receive(:find_by_ark).with(item.ark).and_return(item)
       described_class.perform_now(item.ark)
       expect(item).to have_received(:save)
+    end
+
+    it 'enqueues a CreateManifestJob' do
+      expect do
+        described_class.perform_now(item.ark)
+      end.to have_enqueued_job(CreateManifestJob).with(item.ark)
     end
   end
 

--- a/spec/models/csv_import_task_spec.rb
+++ b/spec/models/csv_import_task_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CsvImportTask, type: :model do
+  subject(:csv_import_task) do
+    FactoryBot.build(:csv_import_task,
+                     csv_import_id: 3,
+                     job_status: 'Complete',
+                     job_type: 'ReindexItemJob',
+                     item_ark: 'ark:/123/abc',
+                     object_type: 'Work',
+                     job_duration: 1.5,
+                     times_started: 1,
+                     start_timestamp: '2019-10-11 10:38:15',
+                     end_timestamp: '2019-10-11 10:38:17')
+  end
+
+  it 'has a parent csv_ipmort record' do
+    expect(csv_import_task.csv_import_id).to eq 3
+  end
+
+  it 'has job_status' do
+    expect(csv_import_task.job_status).to eq 'Complete'
+  end
+
+  it 'has job_type' do
+    expect(csv_import_task.job_type).to eq 'ReindexItemJob'
+  end
+
+  it 'has item_ark' do
+    expect(csv_import_task.item_ark).to eq 'ark:/123/abc'
+  end
+
+  it 'has object_type' do
+    expect(csv_import_task.object_type).to eq 'Work'
+  end
+
+  it 'has job_duration' do
+    expect(csv_import_task.job_duration).to eq 1.5
+  end
+
+  it 'has times_started' do
+    expect(csv_import_task.times_started).to eq 1
+  end
+
+  it 'has start_timestamp' do
+    expect(csv_import_task.start_timestamp).to eq '2019-10-11 10:38:15'
+  end
+
+  it 'has end_timestamp' do
+    expect(csv_import_task.end_timestamp).to eq '2019-10-11 10:38:17'
+  end
+end


### PR DESCRIPTION
Adds support for future re-parallelizing of ingest:
- CsvImportTask model to track durations of the tasks that get deferred to the end of ingest
- ReindexItemJob to reindex a collection (or in future a Work) after all members have been imported.
- Duration tracking for ReindexItemJob and CreateManifestJob
- Deduplication of ReindexItemJob and CreateManifestJob, so we can perform_later these every time a child is ingested but they will only be enqueued once.

None of this actually gets used yet.