### PR TITLE
CAL-811 Add start and end timestamps to CsvRow status page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,7 @@ Metrics/LineLength:
     - app/controllers/catalog_controller.rb
     - spec/renderers/iiif_viewing_hint_attribute_renderer_spec.rb
     - app/controllers/application_controller.rb
+    - spec/system/csv_import_status_show_spec.rb
 
 Metrics/MethodLength:
   Enabled: true

--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -32,7 +32,7 @@ class CreateManifestJob < ApplicationJob
     end
 
     def log_start
-      @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      @create_manifest_start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       csv_import_task.object_type = item.class
       csv_import_task.job_status = 'In Progress'
       begin
@@ -40,14 +40,14 @@ class CreateManifestJob < ApplicationJob
       rescue NoMethodError
         csv_import_task.times_started = 1
       end
-      csv_import_task.start_timestamp = @start_time
+      csv_import_task.start_timestamp = @create_manifest_start_time
       csv_import_task.save
     end
 
     def log_end
-      @end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      csv_import_task.end_timestamp = @end_time
-      csv_import_task.job_duration = @end_time - @start_time
+      @create_manifest_end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      csv_import_task.end_timestamp = @create_manifest_end_time
+      csv_import_task.job_duration = @create_manifest_end_time - @create_manifest_start_time
       csv_import_task.job_status = 'Complete'
       csv_import_task.save
     end

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -2,8 +2,14 @@
 class CsvRowImportJob < ActiveJob::Base
   def perform(row_id:)
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    ENV["TZ"]
+    ENV["TZ"] = "America/Los_Angeles"
+    Time.zone = "America/Los_Angeles"
+
     @row_id = row_id
     @row = CsvRow.find(@row_id)
+    @row.ingest_record_start_time = Time.current
+
     @row.status = 'In Progress'
     @metadata = JSON.parse(@row.metadata)
     @metadata = @metadata.merge(row_id: @row_id)
@@ -19,7 +25,10 @@ class CsvRowImportJob < ActiveJob::Base
     selected_importer.import(record: record)
     ReindexItemJob.perform_later(record.ark, csv_import_id: @csv_import.id)
     @row.status = "complete"
+
     end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @row.ingest_record_end_time = Time.current
+
     ingest_duration = end_time - start_time
     @row.ingest_duration = ingest_duration
     @row.job_ids_completed << job_id

--- a/app/jobs/reindex_item_job.rb
+++ b/app/jobs/reindex_item_job.rb
@@ -45,7 +45,7 @@ class ReindexItemJob < ApplicationJob
     end
 
     def log_start
-      @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      @reindex_log_start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       csv_import_task.object_type = item.class
       csv_import_task.job_status = 'In Progress'
       begin
@@ -53,14 +53,14 @@ class ReindexItemJob < ApplicationJob
       rescue NoMethodError
         csv_import_task.times_started = 1
       end
-      csv_import_task.start_timestamp = @start_time
+      csv_import_task.start_timestamp = @reindex_log_start_time
       csv_import_task.save
     end
 
     def log_end
-      @end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      csv_import_task.end_timestamp = @end_time
-      csv_import_task.job_duration = @end_time - @start_time
+      @reindex_log_end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      csv_import_task.end_timestamp = @reindex_log_end_time
+      csv_import_task.job_duration = @reindex_log_end_time - @reindex_log_start_time
       csv_import_task.job_status = 'Complete'
       csv_import_task.save
     end

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -91,7 +91,7 @@
             <th class="sorting_desc">Row&nbsp;#</th>
             <th>Item Ark</th>
             <th>Object Type</th>
-            <th>Number of children</th>
+            <th>Children</th>
             <th>Last Updated</th>
             <th>Ingest Start</th>
             <th>Ingest End</th>

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -1,7 +1,9 @@
 <p id="notice"><%= notice %></p>
 <h2>CSV Import <%= @csv_import.id %> <small class='ingest-small'>| <%= File.basename(@csv_import.manifest.to_s) %> | <%= @csv_import.record_count %> queued records | <a href="/csv_imports/<%= @csv_import.id %>/log"> Ingest Log</a> | <a href="/csv_imports/<%= @csv_import.id %>.csv">CSV</a></small></h2>
 <h3>Current row count: <%= @csv_rows.count %> | Total record count: <%= @csv_import.record_count %></h3>
-<h4 class='ingest-gray'>(Refresh page to view updated ingest)</h4>
+<h4 class='ingest-md-gray'>
+  <a href="javascript:window.location.href=window.location.href">Refresh page to view updated ingest</a> | Time displayed in seconds
+  </h4>
 <p>
   <span class='ingest-md-gray'><label> Uploaded by: </label></span>
   <span> <%= @csv_import.user.name %> </span>
@@ -10,178 +12,158 @@
 <div class="panel-body">
   <div class="ingest-metrics-table">
     <div class="i-m-table">
-    <h4>Full CSV import metrics (<%= @csv_import.record_count %> records)</h4>
-    <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
-      <thead>
-        <tr role='row'>
-          <th>
-            Start time
-          </th>
-          <th>
-            Total elapsed time
-          </th>
-          <th>
-            Average time per record
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><%= @csv_import.created_at.strftime('%e %b %Y %l:%M %p') %></td>
-          <td>
-            <% if @csv_import.elapsed_time == nil %>
-              <span class='ingest-md-gray'>waiting for ingest to finish</span>
-            <% else %>
-              <%= @csv_import.elapsed_time.round(2) %> seconds
-            <% end %>
-          </td>
-          <td>
-            <% if @csv_import.elapsed_time_per_record == nil %>
-              <span class='ingest-md-gray'>waiting for ingest to finish</span>
-            <% else %>
-              <%= @csv_import.elapsed_time_per_record.round(2) %> seconds
-            <% end %>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <h4>Full CSV import metrics (<%= @csv_import.record_count %> records)</h4>
+      <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
+        <thead>
+          <tr role='row'>
+            <th> Start time </th>
+            <th> Total elapsed time </th>
+            <th> Average time per record </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= @csv_import.created_at.strftime('%e %b %Y %l:%M %p') %></td>
+            <td>
+              <% if @csv_import.elapsed_time == nil %>
+                <span class='ingest-md-gray'>waiting for ingest to finish</span>
+              <% else %>
+                <%= @csv_import.elapsed_time.round(2) %> seconds
+              <% end %>
+            </td>
+            <td>
+              <% if @csv_import.elapsed_time_per_record == nil %>
+                <span class='ingest-md-gray'>waiting for ingest to finish</span>
+              <% else %>
+                <%= @csv_import.elapsed_time_per_record.round(2) %> seconds
+              <% end %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-    <br/>
+      <br/>
 
-    <h4>Row ingest metrics (<%= @csv_import.record_count %> records)</h4>
+      <h4>Row ingest metrics (<%= @csv_import.record_count %> records)</h4>
       (Not including reindexing & manifest creation).
 
-    <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
-      <thead>
-        <tr role="row">
-          <th>
-            Minimum
-          </th>
-          <th>
-            Maximum
-          </th>
-          <th>
-            Mean
-          </th>
-          <th>
-            Median
-          </th>
-          <th>
-            Standard deviation
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <% if @csv_rows.count != @csv_import.record_count %>
-         <tr>
-          <td colspan='5' class='ingest-md-gray'>Metrics will display after all records have been ingested.</td>
-        </tr>
-      <% else %>
-        <tr>
-          <td>
-            <%= @min_ingest_duration %><br/></td>
-          <td>
-            <%= @max_ingest_duration || nil %></td>
-          <td>
-            <%= @mean_ingest_duration || nil %></td>
-          <td>
-            <%= @median_ingest_duration || nil %></td>
-          <td>
-            <%= @standard_deviation_ingest_duration || nil %></td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
+      <table class="table-condensed table-striped no-footer ingest-metrics" role="grid">
+        <thead>
+          <tr role="row">
+            <th> Minimum </th>
+            <th> Maximum </th>
+            <th> Mean </th>
+            <th> Median </th>
+            <th> Standard deviation </th>
+          </tr>
+        </thead>
+        <tbody>
+          <% if @csv_rows.count != @csv_import.record_count %>
+           <tr>
+            <td colspan='5' class='ingest-md-gray'>Metrics will display after all records have been ingested.</td>
+          </tr>
+        <% else %>
+          <tr>
+            <td> <%= @min_ingest_duration %><br/></td>
+            <td> <%= @max_ingest_duration || nil %></td>
+            <td> <%= @mean_ingest_duration || nil %></td>
+            <td> <%= @median_ingest_duration || nil %></td>
+            <td> <%= @standard_deviation_ingest_duration || nil %></td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <br/>
+
+<hr class='ingest-hr'>
+
+  <div class="ingest-metrics-table">
+  <% Time.zone = "America/Los_Angeles" %>
+  <% current_time = Time.current %>
+  <h4>Current time: <%= current_time.strftime('%e %b %Y %l:%M:%S:%L %p') %></h4>
+    <div class="i-m-table">
+      <table class="table-condensed table-striped datatable dataTable no-footer 
+      v_logs ingest-metrics" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
+        <thead>
+          <tr role="row">
+            <th class="sorting_desc">Row&nbsp;#</th>
+            <th>Item Ark</th>
+            <th>Object Type</th>
+            <th>Number of children</th>
+            <th>Last Updated</th>
+            <th>Ingest Start</th>
+            <th>Ingest End</th>
+            <th>Ingest Duration</th>
+            <th>Status</th>
+            <th>Error message(s)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @csv_rows.each do |csv_row| %>
+            <tr>
+              <td><%= csv_row.row_number || "Unknown" %></td>
+              <td><%= JSON.parse(csv_row.metadata)["Item ARK"] || "Unknown" %></td>
+              <td><%= csv_row.object_type || "Unknown" %></td>
+              <td><%= csv_row.no_of_children || "Unknown" %></td>
+              <td><%= csv_row.updated_at.strftime('%e %b %Y %l:%M %p') || "Unknown" %></td>
+              <% if csv_row.ingest_record_start_time == nil %>
+                <td>Unknown</td>
+              <% else %>
+                <td><%= csv_row.ingest_record_start_time.strftime('%e %b %Y %l:%M:%S:%L %p') || "Unknown" %></td>
+              <% end %>
+              <% if csv_row.ingest_record_end_time == nil %>
+                <td>Unknown</td>
+              <% else %>
+                <td><%= csv_row.ingest_record_end_time.strftime('%e %b %Y %l:%M:%S:%L %p') || "Unknown" %></td>
+              <% end %>
+              <% if csv_row.ingest_duration == nil %>
+                <td>Unknown</td>
+              <% else %>
+                <td style='text-align: center'><%= csv_row.ingest_duration.round(3) || "Unknown" %></td>
+              <% end %>
+              <td><%= csv_row.status || "Unknown" %></td>
+              <td><%= csv_row.error_messages || "" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <hr class='ingest-hr'>
+
+  <div class="ingest-metrics-table">
+    <h4>CSV import tasks</h4>
+    <div class="i-m-table">
+      <table class="table-condensed table-striped datatable dataTable no-footer 
+      v_logs ingest-metrics" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
+        <thead>
+          <tr role="row">
+            <th class="sorting_desc"> Job Type </th>
+            <th> Item Ark </th>
+            <th> Object Type </th>
+            <th> Job Duration (s) </th>
+            <th> Status </th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @csv_import_tasks.each do |csv_import_task| %>
+            <tr>
+              <td><%= csv_import_task.job_type || "Unknown" %></td>
+              <td><%= csv_import_task.item_ark || "Unknown" %></td>
+              <td><%= csv_import_task.object_type || "Unknown" %></td>
+              <% if csv_import_task.job_duration == nil %>
+                <td>Unknown</td>
+              <% else %>
+                <td style='text-align: center'><%= csv_import_task.job_duration.round(3) || "Unknown" %></td>
+              <% end %>
+              <td><%= csv_import_task.job_status || "Unknown" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
-<br/>
-
-<hr class='ingest-hr'>
-<table class="table-condensed table-striped datatable dataTable no-footer 
-v_logs ingest-metrics" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
-  <thead>
-    <tr role="row">
-      <th class="sorting_desc">
-        Row&nbsp;#
-      </th>
-      <th>
-        Item Ark
-      </th>
-      <th>
-        Object Type
-      </th>
-      <th>
-        Number of children
-      </th>
-      <th>
-        Last Updated
-      </th>
-      <th>
-        Ingest Duration (in seconds)
-      </th>
-      <th>
-        Status
-      </th>
-      <th>
-        Error message(s)
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @csv_rows.each do |csv_row| %>
-      <tr>
-        <td><%= csv_row.row_number || "Unknown" %></td>
-        <td><%= JSON.parse(csv_row.metadata)["Item ARK"] || "Unknown" %></td>
-        <td><%= csv_row.object_type || "Unknown" %></td>
-        <td><%= csv_row.no_of_children || "Unknown" %></td>
-        <td><%= csv_row.updated_at.strftime('%e %b %Y %l:%M %p') || "Unknown" %></td>
-        <% if csv_row.ingest_duration == nil %>
-          <td>Unknown</td>
-        <% else %>
-          <td style='text-align: center'><%= csv_row.ingest_duration.round(3) || "Unknown" %></td>
-        <% end %>
-        <td><%= csv_row.status || "Unknown" %></td>
-        <td><%= csv_row.error_messages || "" %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<hr class='ingest-hr'>
-<table class="table-condensed table-striped datatable dataTable no-footer 
-v_logs ingest-metrics" role="grid" data-order="[[ 1, &quot;asc&quot; ]]">
-  <thead>
-    <tr role="row">
-      <th class="sorting_desc">
-        Job Type
-      </th>
-      <th>
-        Item Ark
-      </th>
-      <th>
-        Object Type
-      </th>
-      <th>
-        Job Duration (s)
-      </th>
-      <th>
-        Status
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @csv_import_tasks.each do |csv_import_task| %>
-      <tr>
-        <td><%= csv_import_task.job_type || "Unknown" %></td>
-        <td><%= csv_import_task.item_ark || "Unknown" %></td>
-        <td><%= csv_import_task.object_type || "Unknown" %></td>
-        <% if csv_import_task.job_duration == nil %>
-          <td>Unknown</td>
-        <% else %>
-          <td style='text-align: center'><%= csv_import_task.job_duration.round(3) || "Unknown" %></td>
-        <% end %>
-        <td><%= csv_import_task.job_status || "Unknown" %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>

--- a/db/migrate/20191025023335_add_start_and_end_timestamps_to_csv_row.rb
+++ b/db/migrate/20191025023335_add_start_and_end_timestamps_to_csv_row.rb
@@ -1,0 +1,6 @@
+class AddStartAndEndTimestampsToCsvRow < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_rows, :ingest_record_start_time, :timestamp 
+    add_column :csv_rows, :ingest_record_end_time, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191011173814) do
+ActiveRecord::Schema.define(version: 20191025045749) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -110,6 +110,8 @@ ActiveRecord::Schema.define(version: 20191011173814) do
     t.float "ingest_duration", limit: 24
     t.string "object_type"
     t.integer "no_of_children"
+    t.timestamp "ingest_record_start_time"
+    t.timestamp "ingest_record_end_time"
   end
 
   create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/models/csv_import_task_spec.rb
+++ b/spec/models/csv_import_task_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe CsvImportTask, type: :model do
                      object_type: 'Work',
                      job_duration: 1.5,
                      times_started: 1,
-                     start_timestamp: '2019-10-11 10:38:15',
-                     end_timestamp: '2019-10-11 10:38:17')
+                     start_timestamp: '2019-10-11 10:38:15:000 PM',
+                     end_timestamp: '2019-10-11 10:38:17:000 PM')
   end
 
-  it 'has a parent csv_ipmort record' do
+  it 'has a parent csv_import record' do
     expect(csv_import_task.csv_import_id).to eq 3
   end
 
@@ -45,10 +45,10 @@ RSpec.describe CsvImportTask, type: :model do
   end
 
   it 'has start_timestamp' do
-    expect(csv_import_task.start_timestamp).to eq '2019-10-11 10:38:15'
+    expect(csv_import_task.start_timestamp).to eq '2019-10-11 10:38:15.000000000 -0700'
   end
 
   it 'has end_timestamp' do
-    expect(csv_import_task.end_timestamp).to eq '2019-10-11 10:38:17'
+    expect(csv_import_task.end_timestamp).to eq '2019-10-11 10:38:17.000000000 -0700'
   end
 end

--- a/spec/system/csv_import_status_show_spec.rb
+++ b/spec/system/csv_import_status_show_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
       expect(page).to have_content 0.58 # std_deviation
       expect(page).to have_content 'Work'
       expect(page).to have_content '0'
-      expect(page).to have_content 'Start Time'
-      expect(page).to have_content 'End Time'
+      expect(page).to have_content 'Ingest Start'
+      expect(page).to have_content 'Ingest End'
     end
   end
 end

--- a/spec/system/csv_import_status_show_spec.rb
+++ b/spec/system/csv_import_status_show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
       expect(page).to have_content '3'
       expect(page).to have_content 'here is your error'
       expect(page).to have_content 'Current row count'
-      expect(page).to have_content '(Refresh page to view updated ingest)'
+      expect(page).to have_content 'Refresh page to view updated ingest'
       expect(page).to_not have_content 'Puppy'
       expect(page).to have_content 'Minimum'
       expect(page).to have_content 'Maximum'

--- a/spec/system/csv_import_status_show_spec.rb
+++ b/spec/system/csv_import_status_show_spec.rb
@@ -4,9 +4,12 @@ include Warden::Test::Helpers
 
 RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
   context 'logged in as an admin user' do
+    ENV["TZ"]
+    ENV["TZ"] = "America/Los_Angeles"
+    Time.zone = "America/Los_Angeles"
     let(:admin_user) { FactoryBot.create(:admin) }
     let(:csv_import) { FactoryBot.create(:csv_import, record_count: 3) }
-    let(:csv_row1) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, ingest_duration: 0.869, object_type: 'Collection', no_of_children: 2) }
+    let(:csv_row1) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, ingest_duration: 0.869, object_type: 'Collection', no_of_children: 2, ingest_record_start_time: '23 Oct 2019 12:04:01:491 PM', ingest_record_end_time: '23 Oct 2019 12:04:01:501 PM') }
     let(:csv_row2) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, ingest_duration: 2.181, object_type: 'Work', no_of_children: 0) }
     let(:csv_row3) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, ingest_duration: 1.039, object_type: 'Work', no_of_children: 0) }
 
@@ -21,7 +24,6 @@ RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
     it 'starts the import' do
       visit "/csv_imports/#{csv_import.id}"
       expect(page).to have_content csv_import.id
-      expect(page).to have_content csv_import.created_at.strftime('%e %b %Y %l:%M %p')
       expect(page).to have_content 'complete'
       expect(page).to have_content '3'
       expect(page).to have_content 'here is your error'
@@ -42,6 +44,8 @@ RSpec.describe 'Status of all CSV Imports', :clean, type: :system, js: true do
       expect(page).to have_content 0.58 # std_deviation
       expect(page).to have_content 'Work'
       expect(page).to have_content '0'
+      expect(page).to have_content 'Start Time'
+      expect(page).to have_content 'End Time'
     end
   end
 end

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
       visit new_csv_import_path
       # Fill in and submit the form
       attach_file('csv_import[manifest]', csv_file, make_visible: true)
-      expect(page).to have_content("You sucessfully uploaded this CSV: all_fields.csv")
+      expect(page).to have_content('You sucessfully uploaded this CSV: all_fields.csv')
 
       click_on 'Preview Import'
 
@@ -33,11 +33,11 @@ RSpec.describe 'Importing records from a CSV file', :clean, type: :system, js: t
       csv_import = CsvImport.last
 
       expect(page).to have_content("CSV Import #{csv_import.id}")
-      expect(page).to have_content("Full CSV import metrics")
-      expect(page).to have_content("Row ingest metrics")
+      expect(page).to have_content('Full CSV import metrics')
+      expect(page).to have_content('Row ingest metrics')
       expect(csv_import.record_count).to eq 2
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs.map { |a| a[:job] }).to include(StartCsvImportJob)
-      expect(page).to have_content("Ingest Duration (in seconds)")
+      expect(page).to have_content('Ingest Duration')
     end
   end
 end


### PR DESCRIPTION
Connected to: [CAL-811](https://jira.library.ucla.edu/browse/CAL-811)

+ The CsvImport show page shows the start and end times of the CsvImport as a whole
+ The table of CsvRows has columns for start and end times of each CsvRow

on the dev server

<img width="1512" alt="Screen Shot 2019-10-25 at 8 56 21 AM" src="https://user-images.githubusercontent.com/751697/67585955-6735ff80-f705-11e9-924f-597606a5ea3d.png">

---

