### PR TITLE
derive CsvImport status by inspecting sub-jobs

### DIFF
--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -33,7 +33,7 @@ class CsvImportsController < ApplicationController
   def create
     @csv_import.user = current_user
     @csv_import.import_file_path = '/opt/data'
-    @csv_import.status = 'In Progess'
+    @csv_import.status = 'queued'
     preserve_cache
     if @csv_import.save
       @csv_import.queue_start_job

--- a/app/importers/californica_importer.rb
+++ b/app/importers/californica_importer.rb
@@ -22,23 +22,13 @@ class CalifornicaImporter
       depositor_id: @depositor_id,
       batch_id: @csv_import.id
     }
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    log_start
 
     record_importer = ::RecordImporter.new(error_stream: @error_stream, info_stream: @info_stream, attributes: attrs)
     raise "CSV file #{@csv_file} did not validate" unless parser.validate
     csv_table = CSV.parse(File.read(@csv_file), headers: true)
     record_importer.csv_table = csv_table
     Darlingtonia::Importer.new(parser: parser, record_importer: record_importer, info_stream: @info_stream, error_stream: @error_stream).import
-
-    finalize_import
-
-    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    elapsed_time = end_time - start_time
-    elapsed_time_per_record = elapsed_time / parser.records.count
-    @csv_import.elapsed_time = elapsed_time
-    @csv_import.elapsed_time_per_record = elapsed_time_per_record
-    @csv_import.status = 'complete'
-    @csv_import.save
     @info_stream << @csv_import
   end
 
@@ -47,6 +37,12 @@ class CalifornicaImporter
     parser.reindex_collections
     parser.build_iiif_manifests
     @csv_import.csv_rows.where(status: 'pending finalization').update_all(status: 'complete')
+  end
+
+  def log_start
+    @csv_import.start_time = Time.current
+    @csv_import.status = 'in progress'
+    @csv_import.save
   end
 
   def parser

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -1,19 +1,10 @@
 # frozen_string_literal: true
 class CsvRowImportJob < ActiveJob::Base
   def perform(row_id:)
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    ENV["TZ"]
-    ENV["TZ"] = "America/Los_Angeles"
-    Time.zone = "America/Los_Angeles"
-
-    @row_id = row_id
-    @row = CsvRow.find(@row_id)
-    @row.ingest_record_start_time = Time.current
-
-    @row.status = 'In Progress'
-    @metadata = JSON.parse(@row.metadata)
-    @metadata = @metadata.merge(row_id: @row_id)
-    @csv_import = CsvImport.find(@row.csv_import_id)
+    log_start
+    @metadata = JSON.parse(csv_row.metadata)
+    @metadata = @metadata.merge(row_id: row_id)
+    @csv_import = CsvImport.find(csv_row.csv_import_id)
     import_file_path = @csv_import.import_file_path
     record = Darlingtonia::InputRecord.from(metadata: @metadata, mapper: CalifornicaMapper.new(import_file_path: import_file_path))
 
@@ -24,20 +15,12 @@ class CsvRowImportJob < ActiveJob::Base
                         end
     selected_importer.import(record: record)
     ReindexItemJob.perform_later(record.ark, csv_import_id: @csv_import.id)
-    @row.status = "complete"
-
-    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    @row.ingest_record_end_time = Time.current
-
-    ingest_duration = end_time - start_time
-    @row.ingest_duration = ingest_duration
-    @row.job_ids_completed << job_id
-    @row.save
+    log_end
   rescue => e
-    @row.status = 'error'
-    @row.job_ids_errored << job_id
-    @row.error_messages << e.message
-    @row.save
+    csv_row.status = 'error'
+    csv_row.job_ids_errored << job_id
+    csv_row.error_messages << e.message
+    csv_row.save
   end
 
   def collection_record_importer
@@ -47,4 +30,34 @@ class CsvRowImportJob < ActiveJob::Base
   def actor_record_importer
     ::ActorRecordImporter.new(attributes: @metadata)
   end
+
+  private
+
+    def csv_import
+      @csv_import ||= CsvImport.find(csv_row.csv_import_id)
+    end
+
+    def csv_row
+      @csv_row ||= CsvRow.find(arguments[0][:row_id])
+    end
+
+    def log_end
+      csv_row.status = "complete"
+      csv_row.ingest_record_end_time = Time.current
+      csv_row.ingest_duration = csv_row.ingest_record_end_time - csv_row.ingest_record_start_time
+      csv_row.job_ids_completed << job_id
+      csv_row.save
+
+      Californica::CsvImportService.new(csv_import).update_status
+    end
+
+    def log_start
+      @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      ENV["TZ"] = "America/Los_Angeles"
+      Time.zone = "America/Los_Angeles"
+
+      csv_row.ingest_record_start_time = Time.current
+      csv_row.status = 'in progress'
+      csv_row.save
+    end
 end

--- a/app/jobs/start_csv_import_job.rb
+++ b/app/jobs/start_csv_import_job.rb
@@ -8,7 +8,7 @@ class StartCsvImportJob < ApplicationJob
     setup_logging
     @info_stream << "StartCsvImportJob ~ Starting import with batch ID: #{csv_import_id}"
     importer = CalifornicaImporter.new(@csv_import, info_stream: @info_stream, error_stream: @error_stream)
-    @csv_import.elapsed_time = importer.import
+    importer.import
 
   rescue => e
     @error_stream << "StartCsvImportJob failed: #{e.message}\n#{e.backtrace.inspect}"

--- a/app/models/csv_import.rb
+++ b/app/models/csv_import.rb
@@ -6,6 +6,7 @@ class CsvImport < ApplicationRecord
   delegate :errors, to: :manifest, prefix: true
   delegate :records, to: :manifest, prefix: true
   has_many :csv_rows
+  has_many :csv_import_tasks
 
   def queue_start_job
     StartCsvImportJob.perform_later(id)

--- a/db/migrate/20191031202512_add_start_time_to_csv_import.rb
+++ b/db/migrate/20191031202512_add_start_time_to_csv_import.rb
@@ -1,0 +1,5 @@
+class AddStartTimeToCsvImport < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_imports, :start_time, :datetime
+  end
+end

--- a/db/migrate/20191031202528_add_end_time_to_csv_import.rb
+++ b/db/migrate/20191031202528_add_end_time_to_csv_import.rb
@@ -1,0 +1,5 @@
+class AddEndTimeToCsvImport < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_imports, :end_time, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191025045749) do
+ActiveRecord::Schema.define(version: 20191031202528) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -92,6 +92,8 @@ ActiveRecord::Schema.define(version: 20191025045749) do
     t.integer "record_count"
     t.float "elapsed_time", limit: 24
     t.float "elapsed_time_per_record", limit: 24
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.index ["user_id"], name: "index_csv_imports_on_user_id"
   end
 

--- a/spec/controllers/csv_imports_controller_spec.rb
+++ b/spec/controllers/csv_imports_controller_spec.rb
@@ -192,6 +192,11 @@ RSpec.describe CsvImportsController, type: :controller do
           end.to change(CsvImport, :count).by(1)
         end
 
+        it 'sets the new CsvImport status to \'queued\'' do
+          post :create, params: { csv_import: valid_attributes }
+          expect(CsvImport.last.status).to eq 'queued'
+        end
+
         it 'redirects to the show page for the newly created record' do
           post :create, params: { csv_import: valid_attributes }
           expect(response).to redirect_to(CsvImport.last)

--- a/spec/importers/californica_importer_spec.rb
+++ b/spec/importers/californica_importer_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe CalifornicaImporter, :clean, inline_jobs: true do
     end
   end
 
+  describe '#log_start' do
+    it 'sets \'start_time\'' do
+      expect(csv_import.start_time).to be_nil
+      importer.log_start
+      expect(csv_import.start_time).not_to be_nil
+    end
+
+    it 'sets \'status\' to \'in progress\'' do
+      importer.log_start
+      expect(csv_import.status).to eq 'in progress'
+    end
+  end
+
   describe 'CSV import' do
     it 'has an import_file_path' do
       expect(importer.import_file_path).to eq csv_import.import_file_path

--- a/spec/services/californica/csv_import_service_spec.rb
+++ b/spec/services/californica/csv_import_service_spec.rb
@@ -30,4 +30,78 @@ RSpec.describe Californica::CsvImportService do
       expect(service.csv.to_s).to match expected_csv
     end
   end
+
+  describe '#update_status' do
+    let(:csv_import) do
+      csv_import = FactoryBot.create(:csv_import,
+                                     status: 'in progress',
+                                     start_time: Time.zone.parse('1980-09-21 12:05:00'),
+                                     record_count: 3)
+      FactoryBot.create(:csv_row,
+                        csv_import_id: csv_import.id,
+                        metadata: '{"Item ARK": "ark:/abc/123456"}',
+                        ingest_record_end_time: Time.zone.parse('1980-09-21 12:05:14'),
+                        status: 'complete')
+      FactoryBot.create(:csv_row,
+                        csv_import_id: csv_import.id,
+                        metadata: '{"Item ARK": "ark:/abc/654321"}',
+                        ingest_record_end_time: Time.zone.parse('1980-09-21 12:05:18'),
+                        status: 'complete')
+      FactoryBot.create(:csv_row,
+                        csv_import_id: csv_import.id,
+                        metadata: '{"Item ARK": "ark:/abc/918274"}',
+                        ingest_record_end_time: Time.zone.parse('1980-09-21 12:05:15'),
+                        status: 'complete')
+      FactoryBot.create(:csv_import_task,
+                        csv_import_id: csv_import.id,
+                        end_timestamp: Time.zone.parse('1980-09-21 12:05:16'),
+                        job_status: 'complete')
+      FactoryBot.create(:csv_import_task,
+                        csv_import_id: csv_import.id,
+                        end_timestamp: Time.zone.parse('1980-09-21 12:05:45'),
+                        job_status: 'complete')
+      FactoryBot.create(:csv_import_task,
+                        csv_import_id: csv_import.id,
+                        end_timestamp: Time.zone.parse('1980-09-21 12:05:16'),
+                        job_status: 'complete')
+      csv_import
+    end
+
+    it 'sets the status' do
+      service.update_status
+      expect(csv_import.status).to eq 'complete'
+    end
+
+    it 'sets the end_time' do
+      service.update_status
+      expect(csv_import.end_time).to eq Time.zone.parse('1980-09-21 12:05:45')
+    end
+
+    it 'calculates elapsed_time' do
+      service.update_status
+      expect(csv_import.elapsed_time).to eq 45
+    end
+
+    it 'calculates elapsed_time_per_record' do
+      service.update_status
+      expect(csv_import.elapsed_time_per_record).to eq 15
+    end
+
+    context 'when a CsvRow is not complete' do
+      before do
+        FactoryBot.create(:csv_row,
+                          csv_import_id: csv_import.id,
+                          metadata: '{"Item ARK": "ark:/abc/2468"}',
+                          status: 'in progress',
+                          ingest_record_end_time: Time.zone.parse('1980-09-21 12:05:18'))
+      end
+
+      it 'does not update the CsvImport' do
+        service.update_status
+        expect(csv_import.status).to eq 'in progress'
+      end
+    end
+
+    context 'when a CsvImportTask is incomplete'
+  end
 end


### PR DESCRIPTION
Previously CsvImport status and elapsed_time were set at the end of StartCsvImportJob. This worked when the various sub-jobs were executed inline, but not that they are queued and executed in parallel it is not appropriate.

Instead, staus and elapsed_time are set by CsvImportService.update_status, which executes at the end of each sub-job.

update_status queries all sub-tasks of a CsvImport (CsvRow and CsvImportTask objects). If all have statuses of 'complete' or 'error', then it:
- sets the CsvImport status to 'complete'.
- sets the CsvImport end_time to that of the last sub-task to complete, and calculates elapsed_time and elapsed_time_per_record accordingly.