### PR TITLE
don't repeat CsvRows when re-running CalifornicaImporter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,6 +138,11 @@ RSpec/LetSetup:
 RSpec/NotToNot:
   Enabled: false
 
+RSpec/SubjectStub:
+  Enabled: true
+  Exclude:
+    - spec/importers/record_importer_spec.rb
+
 Style/BlockDelimiters:
   Exclude:
     - 'spec/system/search_catalog_spec.rb'

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -32,7 +32,7 @@ class CsvImportsController < ApplicationController
   def create
     @csv_import.user = current_user
     @csv_import.import_file_path = '/opt/data'
-    @csv_import.status = 'In Progess'
+    @csv_import.status = 'in progress'
     preserve_cache
     if @csv_import.save
       @csv_import.queue_start_job

--- a/app/importers/record_importer.rb
+++ b/app/importers/record_importer.rb
@@ -17,7 +17,9 @@ class RecordImporter < Darlingtonia::HyraxRecordImporter
   end
 
   def import(record:)
-    csv_row = CsvRow.create(
+    # NOTE: if the CsvRow object has already been created (e.g. if the job failed and restarted), then this will make a new object but silently fail to save it because the uniqueness validation fails.
+    # This is the desired behavior, because it preserves the original CsvRow object with its status (potentially 'completed').
+    CsvRow.create(
       metadata: record.mapper.metadata.to_json,
       row_number: record.mapper.row_number,
       csv_import_id: batch_id,
@@ -25,7 +27,6 @@ class RecordImporter < Darlingtonia::HyraxRecordImporter
       no_of_children: count_children(record),
       status: 'queued'
     )
-    CsvRowImportJob.perform_now(row_id: csv_row.id)
   end
 
   def count_children(record)

--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -24,7 +24,7 @@ class CreateManifestJob < ApplicationJob
       return unless csv_import_task_id
       @create_manifest_start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       csv_import_task = CsvImportTask.find(csv_import_task_id)
-      csv_import_task.job_status = 'In Progress'
+      csv_import_task.job_status = 'in progress'
       begin
         csv_import_task.times_started += 1
       rescue NoMethodError
@@ -40,7 +40,7 @@ class CreateManifestJob < ApplicationJob
       @create_manifest_end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       csv_import_task.end_timestamp = @create_manifest_end_time
       csv_import_task.job_duration = @create_manifest_end_time - @create_manifest_start_time
-      csv_import_task.job_status = 'Complete'
+      csv_import_task.job_status = 'complete'
       csv_import_task.save
     end
 end

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -10,7 +10,7 @@ class CsvRowImportJob < ActiveJob::Base
     @row = CsvRow.find(@row_id)
     @row.ingest_record_start_time = Time.current
 
-    @row.status = 'In Progress'
+    @row.status = 'in progress'
     @metadata = JSON.parse(@row.metadata)
     @metadata = @metadata.merge(row_id: @row_id)
     @csv_import = CsvImport.find(@row.csv_import_id)

--- a/app/jobs/reindex_item_job.rb
+++ b/app/jobs/reindex_item_job.rb
@@ -34,7 +34,7 @@ class ReindexItemJob < ApplicationJob
       return unless csv_import_task_id
       @reindex_start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       csv_import_task = CsvImportTask.find(csv_import_task_id)
-      csv_import_task.job_status = 'In Progress'
+      csv_import_task.job_status = 'in progress'
       begin
         csv_import_task.times_started += 1
       rescue NoMethodError
@@ -50,7 +50,7 @@ class ReindexItemJob < ApplicationJob
       @reindex_end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       csv_import_task.end_timestamp = @reindex_end_time
       csv_import_task.job_duration = @reindex_end_time - @reindex_start_time
-      csv_import_task.job_status = 'Complete'
+      csv_import_task.job_status = 'complete'
       csv_import_task.save
     end
 

--- a/app/models/csv_row.rb
+++ b/app/models/csv_row.rb
@@ -4,4 +4,5 @@ class CsvRow < ApplicationRecord
   serialize :job_ids_completed, Set
   serialize :job_ids_errored, Set
   serialize :error_messages, Array
+  validates :row_number, uniqueness: { scope: :csv_import_id, message: 'row_number and csv_import must be unique together' }
 end

--- a/spec/importers/californica_importer_spec.rb
+++ b/spec/importers/californica_importer_spec.rb
@@ -134,5 +134,20 @@ RSpec.describe CalifornicaImporter, :clean, inline_jobs: true do
         end
       end
     end
+
+    context 'when the job is re-run after a failure' do
+      let(:csv_row) { FactoryBot.create(:csv_row, csv_import_id: csv_import.id, row_number: 1, status: 'complete') }
+
+      before do
+        csv_row
+        allow(CreateManifestJob).to receive(:perform_now)
+      end
+
+      it 'skips already-imported CsvRows' do
+        allow(CsvRowImportJob).to receive(:perform_now)
+        importer.import
+        expect(CsvRowImportJob).not_to have_received(:perform_now)
+      end
+    end
   end
 end

--- a/spec/importers/record_importer_spec.rb
+++ b/spec/importers/record_importer_spec.rb
@@ -4,6 +4,39 @@ require 'rails_helper'
 RSpec.describe ::RecordImporter, :clean do
   subject(:importer) { described_class.new(error_stream: [], info_stream: [], attributes: { deduplication_field: 'ark' }) }
 
+  context 'when there isn\'t already a CsvRow' do
+    let(:mapper) { instance_double('CalifornicaMapper', metadata: {}, row_number: 1234, object_type: 'Work') }
+    let(:record) { instance_double("Darlingtonia::InputRecord", mapper: mapper) }
+
+    before { allow(importer).to receive(:count_children) }
+
+    it 'creates a CsvRow object' do
+      allow(CsvRow).to receive(:create)
+      importer.import(record: record)
+      expect(CsvRow).to have_received(:create)
+    end
+
+    it 'sets the CsvRow status to "queued"' do
+      importer.import(record: record)
+      expect(CsvRow.find_by(csv_import_id: importer.batch_id, row_number: mapper.row_number).status).to eq 'queued'
+    end
+  end
+
+  context 'when a CsvRow object has already been created' do
+    let(:mapper) { instance_double('CalifornicaMapper', metadata: {}, row_number: 1234, object_type: 'Work') }
+    let(:record) { instance_double("Darlingtonia::InputRecord", mapper: mapper) }
+
+    before do
+      allow(importer).to receive(:count_children)
+      FactoryBot.create(:csv_row, status: 'complete', csv_import_id: importer.batch_id, row_number: mapper.row_number)
+    end
+
+    it 'preserves the old CsvRow and its status' do
+      importer.import(record: record)
+      expect(CsvRow.find_by(csv_import_id: importer.batch_id, row_number: mapper.row_number).status).to eq 'complete'
+    end
+  end
+
   context 'with counts from different importers' do
     before do
       # Stub out some fake results

--- a/spec/models/csv_import_task_spec.rb
+++ b/spec/models/csv_import_task_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CsvImportTask, type: :model do
   subject(:csv_import_task) do
     FactoryBot.build(:csv_import_task,
                      csv_import_id: 3,
-                     job_status: 'Complete',
+                     job_status: 'complete',
                      job_type: 'ReindexItemJob',
                      item_ark: 'ark:/123/abc',
                      object_type: 'Work',
@@ -21,7 +21,7 @@ RSpec.describe CsvImportTask, type: :model do
   end
 
   it 'has job_status' do
-    expect(csv_import_task.job_status).to eq 'Complete'
+    expect(csv_import_task.job_status).to eq 'complete'
   end
 
   it 'has job_type' do

--- a/spec/models/csv_row_spec.rb
+++ b/spec/models/csv_row_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 RSpec.describe CsvRow, type: :model do
   subject(:csv_row) { FactoryBot.build(:csv_row) }
   let(:job_id) { "4344db9d-eef0-46c2-a3f6-5ebc19043b76" }
+  let(:csv_import_1) { FactoryBot.create(:csv_import) }
+  let(:csv_import_2) { FactoryBot.create(:csv_import) }
 
   it 'has a row number' do
     expect(csv_row.row_number).to be_instance_of(Integer)
@@ -29,6 +31,20 @@ RSpec.describe CsvRow, type: :model do
   it 'has metadata that is parsable as json' do
     metadata_hash = JSON.parse(csv_row.metadata)
     expect(metadata_hash['Item ARK']).to eq('21198/zz001pz6jq')
+  end
+
+  it 'validates uniqueness of row_number and csv_import' do
+    expect do
+      FactoryBot.create(:csv_row, csv_import_id: csv_import_1.id, row_number: 1234)
+      FactoryBot.create(:csv_row, csv_import_id: csv_import_1.id, row_number: 1234)
+    end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Row number row_number and csv_import must be unique together')
+  end
+
+  it 'allows the same row_number in different csv_imports' do
+    expect do
+      FactoryBot.create(:csv_row, csv_import_id: csv_import_1.id, row_number: 1234)
+      FactoryBot.create(:csv_row, csv_import_id: csv_import_2.id, row_number: 1234)
+    end.not_to raise_error
   end
 
   context 'tracking background jobs' do


### PR DESCRIPTION
Ensures that, in a situation where a CSV Import job fails and is restarted by sidekiq, CsvRows that have already been ingested are not ingested again.