### PR TITLE
Measure CsvImport time from when the job first begins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,6 +141,7 @@ RSpec/NotToNot:
 RSpec/SubjectStub:
   Enabled: true
   Exclude:
+    - spec/importers/californica_importer_spec.rb
     - spec/importers/record_importer_spec.rb
 
 Style/BlockDelimiters:

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -32,7 +32,7 @@ class CsvImportsController < ApplicationController
   def create
     @csv_import.user = current_user
     @csv_import.import_file_path = '/opt/data'
-    @csv_import.status = 'in progress'
+    @csv_import.status = 'queued'
     preserve_cache
     if @csv_import.save
       @csv_import.queue_start_job

--- a/app/jobs/start_csv_import_job.rb
+++ b/app/jobs/start_csv_import_job.rb
@@ -8,7 +8,7 @@ class StartCsvImportJob < ApplicationJob
     setup_logging
     @info_stream << "StartCsvImportJob ~ Starting import with batch ID: #{csv_import_id}"
     importer = CalifornicaImporter.new(@csv_import, info_stream: @info_stream, error_stream: @error_stream)
-    @csv_import.elapsed_time = importer.import
+    importer.import
 
   rescue => e
     @error_stream << "StartCsvImportJob failed: #{e.message}\n#{e.backtrace.inspect}"

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -23,19 +23,25 @@
         </thead>
         <tbody>
           <tr>
-            <td><%= @csv_import.created_at.in_time_zone("America/Los_Angeles").strftime('%e %b %Y %l:%M %p') %></td>
+            <td>
+              <% if @csv_import.start_time %>
+                <%= @csv_import.start_time.in_time_zone("America/Los_Angeles").strftime('%e %b %Y %l:%M %p') %>
+              <% else %>
+                <span class="ingest-md-gray">n/a</span>
+              <% end %>
+            </td>
             <td>
               <% if @csv_import.elapsed_time == nil %>
                 <span class='ingest-md-gray'>waiting for ingest to finish</span>
               <% else %>
-                <%= @csv_import.elapsed_time.round(2) %> seconds
+                <%= @csv_import.elapsed_time.round %> s
               <% end %>
             </td>
             <td>
               <% if @csv_import.elapsed_time_per_record == nil %>
                 <span class='ingest-md-gray'>waiting for ingest to finish</span>
               <% else %>
-                <%= @csv_import.elapsed_time_per_record.round(2) %> seconds
+                <%= @csv_import.elapsed_time_per_record.round %> s
               <% end %>
             </td>
           </tr>

--- a/db/migrate/20191107174854_add_start_time_to_csv_imports.rb
+++ b/db/migrate/20191107174854_add_start_time_to_csv_imports.rb
@@ -1,0 +1,5 @@
+class AddStartTimeToCsvImports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_imports, :start_time, :datetime
+  end
+end

--- a/db/migrate/20191107174929_add_end_time_to_csv_imports.rb
+++ b/db/migrate/20191107174929_add_end_time_to_csv_imports.rb
@@ -1,0 +1,5 @@
+class AddEndTimeToCsvImports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_imports, :end_time, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191025045749) do
+ActiveRecord::Schema.define(version: 20191107174929) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -92,6 +92,8 @@ ActiveRecord::Schema.define(version: 20191025045749) do
     t.integer "record_count"
     t.float "elapsed_time", limit: 24
     t.float "elapsed_time_per_record", limit: 24
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.index ["user_id"], name: "index_csv_imports_on_user_id"
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   sidekiq:
     image: uclalibrary/californica:latest
-    command: ['bundle', 'exec', 'sidekiq']
+    command: ['bundle', 'exec', 'sidekiq', '-c', '2']
     depends_on:
       - db
       - fedora


### PR DESCRIPTION
Previously, if the job failed and was restarted by sidekiq, only the elapsed time of the last run was recorded. This PR instead records the start time of the *first* run to the database, and uses this to compute elapsed time.