### PR TITLE
disable collection reindexing when ingesting children

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -292,9 +292,16 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   def member_of_collections_attributes
     # A ChildWork will never be a direct member of a Collection
     return if ['ChildWork', 'Page'].include?(metadata["Object Type"])
+
     ark = Ark.ensure_prefix(metadata['Parent ARK'])
     return unless ark
     collection = Collection.find_or_create_by_ark(ark)
+
+    unless collection.recalculate_size == false
+      collection.recalculate_size = false
+      collection.save
+    end
+
     { '0' => { id: collection.id } }
   end
 

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -274,6 +274,20 @@ RSpec.describe CalifornicaMapper do
     end
   end
 
+  describe '#member_of_collections_attributes' do
+    let(:metadata) do
+      { "Parent ARK" => "ark:/123/abc" }
+    end
+
+    let(:collection) { FactoryBot.build(:collection, recalculate_size: true) }
+    before { allow(Collection).to receive(:find_or_create_by_ark).and_return(collection) }
+
+    it 'disables collection reindexing' do
+      mapper.member_of_collections_attributes
+      expect(collection.recalculate_size).to eq false
+    end
+  end
+
   describe '#preservation_copy' do
     context 'when the path starts with a \'/\'' do
       let(:metadata) { { 'File Name' => '/Masters/dlmasters/abc/xyz.tif' } }


### PR DESCRIPTION
Although we have been intending to disable collection reindexing, this has actually only happened while processing the collection row. As a result, it was still very inefficient to ingest csvs that did not begin with a collection.