### PR TITLE
Remove "Description.contents" from Summary

### DIFF
--- a/app/assets/markdown/importer_guide.md
+++ b/app/assets/markdown/importer_guide.md
@@ -255,7 +255,7 @@ Accepts "Subject.conceptTopic" and "Subject.descriptiveTopic" as valid synonyms.
 ### Subject.descriptiveTopic
 
 ### Summary
-Accepts "Summary", "Description.abstract", "Description.contents"
+Accepts "Summary", "Description.abstract"
 
 ### Support
 

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -71,7 +71,7 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     services_contact: "Rights.servicesContact",
     subject: "Subject",
     subject_topic: ["Subject topic", "Subject.conceptTopic", "Subject.descriptiveTopic"],
-    summary: ["Summary", "Description.abstract", "Description.contents"],
+    summary: ["Summary", "Description.abstract"], # Removed Description.contents - Map this CSV colum name to "Contents note" https://jira.library.ucla.edu/browse/CAL-781
     support: "Support",
     iiif_text_direction: "Text direction",
     title: "Title",

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CalifornicaMapper do
       "AltTitle.uniform" => "Protesters with signs in gallery of Los Angeles County Supervisors", # uniform_title
       "Summary" => "Protesters with signs", # summary
       "Description.abstract" => "Abstract description", # summary
-      "Description.contents" => "Contents description", # summary
+      # "Description.contents" => "Contents description", # contents_note
       "Description.history" => "Description history", # provenance
       "Text direction" => "left-to-right", # iiif_text_direction
       "viewingHint" => "paged", # iiif_viewing_hint


### PR DESCRIPTION
Connected to [CAL-750](https://jira.library.ucla.edu/browse/CAL-750)

"Description.contents" has been removed from Summary so it doesn't map to Summary anymore.

We need to Add the "Contents note" before we do [CAL-750](https://jira.library.ucla.edu/browse/CAL-750). https://jira.library.ucla.edu/browse/CAL-781

---

Changes to be committed:
+ modified: `app/assets/markdown/importer_guide.md`
+ modified: `app/importers/californica_mapper.rb`
+ modified: `spec/importers/californica_mapper_spec.rb`