### PR TITLE
CAL-878 Add items to multiple collections on ingest

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -354,12 +354,14 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     end
 
     ### this should return an array of hashes with { id: collection.id } ???
-    { '0' => { id: collection.id } } ===> { 0: ark:/123 }
-    { '1' => { id: collection.id } } ===> { 1: ark:/124 }
 
-    { 0: ark:/123, 1: ark:/124 }
+    { '0' => { id: collection.id } }
+    ###{ '0' => { id: collection.id } } ===> { 0: ark:/123 }
+    ###{ '1' => { id: collection.id } } ===> { 1: ark:/124 }
 
-    [ { 0: ark:/123 }, { 1: ark:/124 } ]
+    ###{ 0: ark:/123, 1: ark:/124 }
+
+    ###[ { 0: ark:/123 }, { 1: ark:/124 } ]
 
   end
 

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -324,7 +324,7 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     return unless CALIFORNICA_TERMS_MAP.keys.include?(name)
 
     Array.wrap(CALIFORNICA_TERMS_MAP[name]).map do |source_field|
-      metadata[source_field]&.split(DELIMITER)
+      metadata[source_field]&.split(DELIMITER) unless metadata[source_field].nil
     end.flatten.compact
   end
 
@@ -334,13 +334,11 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   def member_of_collections_attributes
     # A ChildWork will never be a direct member of a Collection
     return if ['ChildWork', 'Page'].include?(metadata["Object Type"])
-
     arks_array = metadata['Parent ARK'].split('|~|')
-
     collection = []
-    arks_array.each_with_index do |current_ark, index| 
+    arks_array.each_with_index do |current_ark, index|
       ark_string = Ark.ensure_prefix(current_ark)
-      return unless ark_string
+      return 0 unless ark_string
       collection[index] = Collection.find_or_create_by_ark(ark_string)
 
       unless collection[index].recalculate_size == false
@@ -355,16 +353,9 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     end
 
     collection_return
-
-    ### this should return an array of hashes with { id: collection.id } ???
-
-    ###oem { '0' => { id: collection.id } }
-    ###new { '0' => { id: collection1.id }, '1' => { id: collection2.id } }
-
   end
 
-  def collection_builder
-  end
+  def collection_builder; end
 
   def sequence
     metadata['Item Sequence']

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -324,7 +324,7 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     return unless CALIFORNICA_TERMS_MAP.keys.include?(name)
 
     Array.wrap(CALIFORNICA_TERMS_MAP[name]).map do |source_field|
-      metadata[source_field]&.split(DELIMITER) unless metadata[source_field].nil
+      metadata[source_field]&.split(DELIMITER)
     end.flatten.compact
   end
 
@@ -333,12 +333,12 @@ class CalifornicaMapper < Darlingtonia::HashMapper
   # Assume the parent of this object is a collection unless the Object Type is ChildWork
   def member_of_collections_attributes
     # A ChildWork will never be a direct member of a Collection
-    return if ['ChildWork', 'Page'].include?(metadata["Object Type"])
+    return if ['ChildWork', 'Page'].include?(metadata["Object Type"]) || !metadata['Parent ARK']
     arks_array = metadata['Parent ARK'].split('|~|')
     collection = []
+
     arks_array.each_with_index do |current_ark, index|
       ark_string = Ark.ensure_prefix(current_ark)
-      return 0 unless ark_string
       collection[index] = Collection.find_or_create_by_ark(ark_string)
 
       unless collection[index].recalculate_size == false

--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -335,16 +335,32 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     # A ChildWork will never be a direct member of a Collection
     return if ['ChildWork', 'Page'].include?(metadata["Object Type"])
 
-    ark = Ark.ensure_prefix(metadata['Parent ARK'])
-    return unless ark
-    collection = Collection.find_or_create_by_ark(ark)
+    ark_string = Ark.ensure_prefix(metadata['Parent ARK'])
+    if( ark_string =~ '|~|') 
+      arks_array = ark_string.split('|~|')
+    else
+      arks_array[0] = ark_string
+    end
+
+    arks_array.each
+      ark = Ark.ensure_prefix(metadata['Parent ARK'])
+      return unless ark
+      collection = Collection.find_or_create_by_ark(ark)
+    end
 
     unless collection.recalculate_size == false
       collection.recalculate_size = false
       collection.save
     end
 
-    { '0' => { id: collection.id } }
+    ### this should return an array of hashes with { id: collection.id } ???
+    { '0' => { id: collection.id } } ===> { 0: ark:/123 }
+    { '1' => { id: collection.id } } ===> { 1: ark:/124 }
+
+    { 0: ark:/123, 1: ark:/124 }
+
+    [ { 0: ark:/123 }, { 1: ark:/124 } ]
+
   end
 
   def sequence

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe CalifornicaMapper do
 
   describe '#member_of_collections_attributes' do
     let(:metadata) do
-      { "Parent ARK" => "ark:/21198/n1t31k|~|ark:/21198/zz0008hs73" }
+      { "Parent ARK" => "ark:/123/abc" }
     end
 
     let(:collection) { FactoryBot.build(:collection, recalculate_size: true) }

--- a/spec/importers/californica_mapper_spec.rb
+++ b/spec/importers/californica_mapper_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe CalifornicaMapper do
 
   describe '#member_of_collections_attributes' do
     let(:metadata) do
-      { "Parent ARK" => "ark:/123/abc" }
+      { "Parent ARK" => "ark:/21198/n1t31k|~|ark:/21198/zz0008hs73" }
     end
 
     let(:collection) { FactoryBot.build(:collection, recalculate_size: true) }


### PR DESCRIPTION
[Cal 878](https://jira.library.ucla.edu/browse/CAL-878)

Enable the ability to ingest items that belong to more than one collection.

Acceptance criteria:
- [ ] A CSV ingested to Californica with a Parent ARK and a second collection (identified by an ARK) results in items that are added to both the Parent ARK collection and a second designated collection.
