### PR TITLE
Remove code that prepends "Ingesting now" to collection title

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -15,8 +15,8 @@ class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
     {
       "has_model_ssim" => ["Collection"],
       :id => object.id,
-      "title_tesim" => ["Ingesting now: #{object.title.first}"],
-      "title_sim" => ["Ingesting now: #{object.title.first}"],
+      "title_tesim" => ["#{object.title.first}"],
+      "title_sim" => ["#{object.title.first}"],
       "collection_type_gid_ssim" => [object.collection_type_gid],
       "ark_ssi" => object.ark,
       "ursus_id_ssi" => Californica::IdGenerator.blacklight_id_from_ark(object.ark),

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -15,8 +15,8 @@ class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
     {
       "has_model_ssim" => ["Collection"],
       :id => object.id,
-      "title_tesim" => ["#{object.title.first}"],
-      "title_sim" => ["#{object.title.first}"],
+      "title_tesim" => [object.title.first.to_s],
+      "title_sim" => [object.title.first.to_s],
       "collection_type_gid_ssim" => [object.collection_type_gid],
       "ark_ssi" => object.ark,
       "ursus_id_ssi" => Californica::IdGenerator.blacklight_id_from_ark(object.ark),


### PR DESCRIPTION
Prevent the collection title from sometimes displaying the prefix "Ingesting now:" in front of the collection title.

- Acceptance Criteria:

[x] remove code that changes the title during the ingest process (both the code that puts "ingesting now" and the code that removes it when done)
[x] Investigate why the removal part of that code is not being triggered and document.write tickets
