### PR TITLE
Index to title_alpha_numeric_ssort

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -5,8 +5,9 @@ class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
   def generate_solr_document
     return solr_during_indexing unless object.recalculate_size
     super.tap do |solr_doc|
-      solr_doc['ursus_id_ssi'] = Californica::IdGenerator.blacklight_id_from_ark(object.ark)
       solr_doc['thumbnail_url_ss'] = thumbnail_url
+      solr_doc['title_alpha_numeric_ssort'] = object.title.first
+      solr_doc['ursus_id_ssi'] = Californica::IdGenerator.blacklight_id_from_ark(object.ark)
     end
   end
 

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -24,7 +24,7 @@ class WorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_iiif_text_direction_ssi'] = human_readable_iiif_text_direction
       solr_doc['human_readable_iiif_viewing_hint_ssi'] = human_readable_iiif_viewing_hint
       solr_doc['human_readable_rights_statement_tesim'] = human_readable_rights_statement
-      solr_doc['sort_title_ssort'] = object.title.first
+      solr_doc['title_alpha_numeric_ssort'] = object.title.first
       solr_doc['ursus_id_ssi'] = Californica::IdGenerator.blacklight_id_from_ark(object.ark)
       solr_doc['year_isim'] = years
       solr_doc['thumbnail_url_ss'] = thumbnail_url

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe ::CollectionIndexer do
     end
   end
 
+  describe 'sort_title' do
+    let(:attributes) do
+      {
+        ark: 'ark:/123/456',
+        recalculate_size: true,
+        title: ['Primary title']
+      }
+    end
+
+    it 'indexs the only value' do
+      expect(solr_document['title_alpha_numeric_ssort']).to eq 'Primary title'
+    end
+  end
+
   describe '#thumbnail_url' do
     let(:expected_url) { "#{ENV['IIIF_SERVER_URL']}master%2Ffile%2Fpath.jpg/full/!200,200/0/default.jpg" }
 

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe WorkIndexer do
     end
 
     it 'indexs the only value' do
-      expect(solr_document['sort_title_ssort']).to eq 'Primary title'
+      expect(solr_document['title_alpha_numeric_ssort']).to eq 'Primary title'
     end
   end
 


### PR DESCRIPTION
Previously, the field title_ssort was used, breaking sorting in Ursus