### PR TITLE
CAL-913 Strip MARC subfields from all ingested values

### DIFF
--- a/app/importers/californica_mapper.rb
+++ b/app/importers/californica_mapper.rb
@@ -260,6 +260,12 @@ class CalifornicaMapper < Darlingtonia::HashMapper
     end
   end
 
+  # Normalize subject topic to remove MaRC codes (e.g., $z separators)
+  # Replace subject marc codes with double dashes with no surrounding spaces
+  def subject_topic
+    map_field(:subject_topic)&.map { |a| a.gsub(/ \$[a-z] /, '--') }
+  end
+
   # Normalize subject to remove MaRC codes (e.g., $z separators)
   # Replace subject marc codes with double dashes with no surrounding spaces
   def subject


### PR DESCRIPTION
Connected to [CAL-913](https://jira.library.ucla.edu/browse/CAL-913)

---

### Remove **`$-`** characters from the **`subject.topic`** field during imports.   
This is already done for two other fields: **`subject`** and **`named_subject`**.

---

**Acceptance Criteria:**
- [x] the importer strips MARC subfield tags from all fields (i.e. remove the $z or $c, etc.)

**Files**
`app/importers/californica_mapper.rb`

**Verified**
An import was performed to verify that $ (`$z`) characters are removed. Details: [CAL-913](https://jira.library.ucla.edu/browse/CAL-913).

---

**Screenshot**
![image](https://user-images.githubusercontent.com/2350153/89839673-3489b600-db23-11ea-92db-a4144999f581.png)
