### PR TITLE
CAL-948 Revert delete button behavior

### DIFF
--- a/app/controllers/hyrax/child_works_controller.rb
+++ b/app/controllers/hyrax/child_works_controller.rb
@@ -11,7 +11,7 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::WorkPresenter
-
+=begin
     # Override from Hyrax. Because we are using ark-based identifiers we need to both
     # destroy and eradicate an object when it is deleted. Otherwise, a tombstone resource
     # is left in fedora and we cannot re-create an object that has the same ark.
@@ -21,5 +21,6 @@ module Hyrax
       Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
       after_destroy_response(title)
     end
+=end
   end
 end

--- a/app/controllers/hyrax/child_works_controller.rb
+++ b/app/controllers/hyrax/child_works_controller.rb
@@ -11,16 +11,5 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::WorkPresenter
-=begin
-    # Override from Hyrax. Because we are using ark-based identifiers we need to both
-    # destroy and eradicate an object when it is deleted. Otherwise, a tombstone resource
-    # is left in fedora and we cannot re-create an object that has the same ark.
-    def destroy
-      title = curation_concern.to_s
-      return unless curation_concern&.destroy&.eradicate
-      Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
-      after_destroy_response(title)
-    end
-=end
   end
 end

--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -11,7 +11,7 @@ module Hyrax
       def form_class
         Hyrax::CalifornicaCollectionsForm
       end
-
+=begin
       # Override #destroy method from Hyrax. Because we are using ark based identifiers, we need to both
       # destroy and eradicate the object, so that we can re-create a collection object with the same ark if needed
       def destroy
@@ -21,6 +21,7 @@ module Hyrax
           after_destroy_error(params[:id])
         end
       end
+=end
 
       # Override #create method from Hyrax to assign an ark based identifier to any newly created collection objects
       def create

--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -11,17 +11,6 @@ module Hyrax
       def form_class
         Hyrax::CalifornicaCollectionsForm
       end
-=begin
-      # Override #destroy method from Hyrax. Because we are using ark based identifiers, we need to both
-      # destroy and eradicate the object, so that we can re-create a collection object with the same ark if needed
-      def destroy
-        if @collection.destroy.eradicate
-          after_destroy(params[:id])
-        else
-          after_destroy_error(params[:id])
-        end
-      end
-=end
 
       # Override #create method from Hyrax to assign an ark based identifier to any newly created collection objects
       def create

--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -12,7 +12,7 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::WorkPresenter
 
-    """
+=begin
     # Override from Hyrax. Because we are using ark-based identifiers we need to both
     # destroy and eradicate an object when it is deleted. Otherwise, a tombstone resource
     # is left in fedora and we cannot re-create an object that has the same ark.
@@ -23,7 +23,7 @@ module Hyrax
       Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
       after_destroy_response(title)
     end
-    """
+=end
 
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'

--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -12,19 +12,6 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::WorkPresenter
 
-=begin
-    # Override from Hyrax. Because we are using ark-based identifiers we need to both
-    # destroy and eradicate an object when it is deleted. Otherwise, a tombstone resource
-    # is left in fedora and we cannot re-create an object that has the same ark.
-
-    def destroy
-      title = curation_concern.to_s
-      return unless curation_concern&.destroy&.eradicate
-      Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
-      after_destroy_response(title)
-    end
-=end
-
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'
       authorize! :show, curation_concern

--- a/app/controllers/hyrax/works_controller.rb
+++ b/app/controllers/hyrax/works_controller.rb
@@ -12,6 +12,7 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::WorkPresenter
 
+    """
     # Override from Hyrax. Because we are using ark-based identifiers we need to both
     # destroy and eradicate an object when it is deleted. Otherwise, a tombstone resource
     # is left in fedora and we cannot re-create an object that has the same ark.
@@ -22,6 +23,7 @@ module Hyrax
       Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user)
       after_destroy_response(title)
     end
+    """
 
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'

--- a/spec/system/delete_work_spec.rb
+++ b/spec/system/delete_work_spec.rb
@@ -1,3 +1,5 @@
+
+=begin
 # frozen_string_literal: true
 require 'rails_helper'
 include Warden::Test::Helpers
@@ -30,3 +32,5 @@ RSpec.describe 'Delete a Work', :clean, type: :system, js: true do
     end
   end
 end
+=end
+

--- a/spec/system/delete_work_spec.rb
+++ b/spec/system/delete_work_spec.rb
@@ -1,5 +1,3 @@
-
-=begin
 # frozen_string_literal: true
 require 'rails_helper'
 include Warden::Test::Helpers
@@ -32,5 +30,3 @@ RSpec.describe 'Delete a Work', :clean, type: :system, js: true do
     end
   end
 end
-=end
-


### PR DESCRIPTION
Connected to [CAL-948](https://jira.library.ucla.edu/browse/CAL-948) 

- [x] Delete logic in Hyrax is the same as it was out of the box (i.e. remove our custom logic that tries to remove the tombstone)
- Reverts destroy method from this [commit](https://github.com/UCLALibrary/californica/commit/df650ea79360e6e977b1cb51be18c14f70bdefbf#diff-2465ed21125db5507b630f05bc2acbee)

<img width="1280" alt="Screen Shot 2020-10-13 at 12 08 12 PM" src="https://user-images.githubusercontent.com/751697/95904994-1f145080-0d4d-11eb-82b3-5712c7730819.png">
