### PR TITLE
Cal 949 catch tombstone exceptions on re ingest2

### DIFF
--- a/app/importers/actor_record_importer.rb
+++ b/app/importers/actor_record_importer.rb
@@ -97,8 +97,9 @@ class ActorRecordImporter < Darlingtonia::HyraxRecordImporter
         raise "Validation failed: #{error_messages.join(', ')}"
       end
     rescue Ldp::BadRequest
-      ts_uri = "#{ActiveFedora::Base.id_to_uri(Californica::IdGenerator.id_from_ark(created.ark))}/fcr:tombstone"
-      ActiveFedora.fedora.connection.delete(ts_uri)
+      # get the id from the ark and the uri from the id then delete the tombstone
+      tombstone_uri = "#{ActiveFedora::Base.id_to_uri(Californica::IdGenerator.id_from_ark(created.ark))}/fcr:tombstone"
+      ActiveFedora.fedora.connection.delete(tombstone_uri)
       retry if (retries += 1) < 3
     end
   end

--- a/app/importers/collection_record_importer.rb
+++ b/app/importers/collection_record_importer.rb
@@ -8,34 +8,13 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
   end
 
   def create_for(record:)
-    info_stream << "event: collection_import_started, batch_id: #{batch_id}, record_title: #{record.respond_to?(:title) ? record.title : record}\n"
 
     begin
-      retries ||= 0
-      collection = Collection.find_or_create_by_ark(record.ark)
-    rescue Ldp::BadRequest => e
-      # build the backwards ark to query Fedora
-      fedora_ark2 = created.ark
-      fedora_ark3 = fedora_ark2.sub("ark:/", "")
-      fedora_ark4 = fedora_ark3.sub("/", "-")
-      fedora_ark5 = fedora_ark4.reverse
-      fedora_ark6a = fedora_ark5.split("-")
-      fedora_ark6 = fedora_ark6a.first
-      fedora_ark7 = fedora_ark6.scan(/\w/)
-      fedora_ark8 = ""
-      ark_cnt = 0
-      fedora_ark7.each do |ark_l|
-        fedora_ark8 += "/" if ark_cnt.modulo(2).zero?
-        fedora_ark8 += ark_l
-        ark_cnt += 1
-      end
-      fedora_ark8 += "/"
-      fedora_ark9 = fedora_ark8 + fedora_ark5
-      fedora_ark10 = fedora_ark9.sub("/zz/", "/")
-      url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}#{fedora_ark10}/fcr:tombstone"
-      ActiveFedora.fedora.connection.delete(url)
-      retry if (retries += 1) < 3
-    end
+    retries ||= 0
+
+    info_stream << "event: collection_import_started, batch_id: #{batch_id}, record_title: #{record.respond_to?(:title) ? record.title : record}\n"
+
+    collection = Collection.find_or_create_by_ark(record.ark)
     collection.attributes = attributes_for(record: record)
     collection.recalculate_size = false
     if collection.save(update_index: false)
@@ -47,9 +26,38 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
       end
       @failure_count += 1
     end
+    rescue Ldp::Gone => e
+
+    
+    fedora_ark2 = record.ark
+    fedora_ark3 = fedora_ark2.sub("ark:/", "")
+    fedora_ark4 = fedora_ark3.sub("/", "-")
+    fedora_ark5 = fedora_ark4.reverse
+    fedora_ark6a = fedora_ark5.split("-")
+    fedora_ark6 = fedora_ark6a.first
+    fedora_ark7 = fedora_ark6.scan(/\w/)
+    fedora_ark8 = ""
+    ark_cnt = 0
+    fedora_ark7.each do |ark_l|
+      fedora_ark8 += "/" if ark_cnt.modulo(2).zero?
+      fedora_ark8 += ark_l
+      ark_cnt += 1
+    end
+    fedora_ark8 += "/"
+    fedora_ark9 = fedora_ark8 + fedora_ark5
+    fedora_ark10 = fedora_ark9.sub("/zz/", "/")
+    url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}#{fedora_ark10}/fcr:tombstone"
+    ActiveFedora.fedora.connection.delete(url)
+    retry if (retries += 1) < 3
+    end
+
+
+
+
   end
 
   def update_for(existing_record:, update_record:)
+    retries ||= 0
     info_stream << "event: collection_update_started, batch_id: #{batch_id}, ark: #{update_record.ark}\n"
 
     collection = existing_record
@@ -64,6 +72,9 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
       end
       @failure_count += 1
     end
+  rescue Ldp::BadRequest => e
+    raise << "testtesttest"
+    retry if (retries += 1) < 3
   end
 
   private

--- a/app/importers/collection_record_importer.rb
+++ b/app/importers/collection_record_importer.rb
@@ -13,8 +13,9 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
       retries ||= 0
       collection = Collection.find_or_create_by_ark(record.ark)
     rescue Ldp::Gone
-      ts_uri = "#{ActiveFedora::Base.id_to_uri(Californica::IdGenerator.id_from_ark(record.ark))}/fcr:tombstone"
-      ActiveFedora.fedora.connection.delete(ts_uri)
+      # get the id from the ark and the uri from the id then delete the tombstone
+      tombstone_uri = "#{ActiveFedora::Base.id_to_uri(Californica::IdGenerator.id_from_ark(record.ark))}/fcr:tombstone"
+      ActiveFedora.fedora.connection.delete(tombstone_uri)
       retry if (retries += 1) < 3
     end
     collection.attributes = attributes_for(record: record)

--- a/app/importers/collection_record_importer.rb
+++ b/app/importers/collection_record_importer.rb
@@ -8,13 +8,15 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
   end
 
   def create_for(record:)
-
-    begin
-    retries ||= 0
-
     info_stream << "event: collection_import_started, batch_id: #{batch_id}, record_title: #{record.respond_to?(:title) ? record.title : record}\n"
-
-    collection = Collection.find_or_create_by_ark(record.ark)
+    begin
+      retries ||= 0
+      collection = Collection.find_or_create_by_ark(record.ark)
+    rescue Ldp::Gone
+      ts_uri = "#{ActiveFedora::Base.id_to_uri(Californica::IdGenerator.id_from_ark(record.ark))}/fcr:tombstone"
+      ActiveFedora.fedora.connection.delete(ts_uri)
+      retry if (retries += 1) < 3
+    end
     collection.attributes = attributes_for(record: record)
     collection.recalculate_size = false
     if collection.save(update_index: false)
@@ -26,40 +28,10 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
       end
       @failure_count += 1
     end
-    rescue Ldp::Gone => e
-
-    
-    fedora_ark2 = record.ark
-    fedora_ark3 = fedora_ark2.sub("ark:/", "")
-    fedora_ark4 = fedora_ark3.sub("/", "-")
-    fedora_ark5 = fedora_ark4.reverse
-    fedora_ark6a = fedora_ark5.split("-")
-    fedora_ark6 = fedora_ark6a.first
-    fedora_ark7 = fedora_ark6.scan(/\w/)
-    fedora_ark8 = ""
-    ark_cnt = 0
-    fedora_ark7.each do |ark_l|
-      fedora_ark8 += "/" if ark_cnt.modulo(2).zero?
-      fedora_ark8 += ark_l
-      ark_cnt += 1
-    end
-    fedora_ark8 += "/"
-    fedora_ark9 = fedora_ark8 + fedora_ark5
-    fedora_ark10 = fedora_ark9.sub("/zz/", "/")
-    url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}#{fedora_ark10}/fcr:tombstone"
-    ActiveFedora.fedora.connection.delete(url)
-    retry if (retries += 1) < 3
-    end
-
-
-
-
   end
 
   def update_for(existing_record:, update_record:)
-    retries ||= 0
     info_stream << "event: collection_update_started, batch_id: #{batch_id}, ark: #{update_record.ark}\n"
-
     collection = existing_record
     collection.attributes = attributes_for(record: update_record)
     collection.recalculate_size = false
@@ -72,9 +44,6 @@ class CollectionRecordImporter < Darlingtonia::HyraxRecordImporter
       end
       @failure_count += 1
     end
-  rescue Ldp::BadRequest => e
-    raise << "testtesttest"
-    retry if (retries += 1) < 3
   end
 
   private

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -12,42 +12,44 @@ class CsvRowImportJob < ActiveJob::Base
 
     @metadata = JSON.parse(@row.metadata)
 
-    # build the backwards ark to query Fedora
-    fedoraArk2 = @metadata["Item ARK"]
-    fedoraArk3 = fedoraArk2.sub("ark:/","")
-    fedoraArk4 = fedoraArk3.sub("/","-")
-    fedoraArk5 = fedoraArk4.reverse
-    fedoraArk6a = fedoraArk5.split("-")
-    fedoraArk6 = fedoraArk6a.first()
-    fedoraArk7 = fedoraArk6.scan /\w/
-    fedoraArk8 = ""
-    arkCnt = 0
-    fedoraArk7.each do |arkL|
-      if arkCnt.modulo(2) == 0
-        fedoraArk8 += "/"
+    unless @metadata["Item ARK"] == ""
+      # build the backwards ark to query Fedora
+      fedoraArk2 = @metadata["Item ARK"]
+      fedoraArk3 = fedoraArk2.sub("ark:/","")
+      fedoraArk4 = fedoraArk3.sub("/","-")
+      fedoraArk5 = fedoraArk4.reverse
+      fedoraArk6a = fedoraArk5.split("-")
+      fedoraArk6 = fedoraArk6a.first()
+      fedoraArk7 = fedoraArk6.scan /\w/
+      fedoraArk8 = ""
+      arkCnt = 0
+      fedoraArk7.each do |arkL|
+        if arkCnt.modulo(2) == 0
+          fedoraArk8 += "/"
+        end
+        fedoraArk8 += arkL
+        arkCnt += 1
       end
-      fedoraArk8 += arkL
-      arkCnt += 1
-    end
-    fedoraArk8 += "/"
-    fedoraArk9 = fedoraArk8 + fedoraArk5
-    fedoraArk10 = fedoraArk9.sub("/zz/","/")
-
-    # build Fedora URI and remove tombstone if present
-    url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}"
-    fedoraArk11 = url + fedoraArk10
-    uri = URI(fedoraArk11)
-    fedoraResp = Net::HTTP.get_response(uri)
-
-    if fedoraResp.body["ombstone"]
-      fedoraArk11 = fedoraArk11 + "/fcr:tombstone"
+      fedoraArk8 += "/"
+      fedoraArk9 = fedoraArk8 + fedoraArk5
+      fedoraArk10 = fedoraArk9.sub("/zz/","/")
+  
+      # build Fedora URI and remove tombstone if present
+      url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}"
+      fedoraArk11 = url + fedoraArk10
       uri = URI(fedoraArk11)
-      http = Net::HTTP.new(uri.host, uri.port)
-      req = Net::HTTP::Delete.new(uri.path)
-      req.basic_auth ActiveFedora.config.credentials[:user], ActiveFedora.config.credentials[:password]
-      http.request(req)
-      tombstoneMsgAry = Array.new(1, "tombstone removed")
-      @row.error_messages = tombstoneMsgAry
+      fedoraResp = Net::HTTP.get_response(uri)
+  
+      if fedoraResp.body["ombstone"]
+        fedoraArk11 = fedoraArk11 + "/fcr:tombstone"
+        uri = URI(fedoraArk11)
+        http = Net::HTTP.new(uri.host, uri.port)
+        req = Net::HTTP::Delete.new(uri.path)
+        req.basic_auth ActiveFedora.config.credentials[:user], ActiveFedora.config.credentials[:password]
+        http.request(req)
+        tombstoneMsgAry = Array.new(1, "tombstone removed")
+        @row.error_messages = tombstoneMsgAry
+      end
     end
 
     @row.status = @metadata["Object Type"].include?("Page") ? 'not ingested' : 'in progress'

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -14,41 +14,39 @@ class CsvRowImportJob < ActiveJob::Base
 
     unless @metadata["Item ARK"] == ""
       # build the backwards ark to query Fedora
-      fedoraArk2 = @metadata["Item ARK"]
-      fedoraArk3 = fedoraArk2.sub("ark:/","")
-      fedoraArk4 = fedoraArk3.sub("/","-")
-      fedoraArk5 = fedoraArk4.reverse
-      fedoraArk6a = fedoraArk5.split("-")
-      fedoraArk6 = fedoraArk6a.first()
-      fedoraArk7 = fedoraArk6.scan /\w/
-      fedoraArk8 = ""
-      arkCnt = 0
-      fedoraArk7.each do |arkL|
-        if arkCnt.modulo(2) == 0
-          fedoraArk8 += "/"
-        end
-        fedoraArk8 += arkL
-        arkCnt += 1
+      fedora_ark2 = @metadata["Item ARK"]
+      fedora_ark3 = fedora_ark2.sub("ark:/", "")
+      fedora_ark4 = fedora_ark3.sub("/", "-")
+      fedora_ark5 = fedora_ark4.reverse
+      fedora_ark6a = fedora_ark5.split("-")
+      fedora_ark6 = fedora_ark6a.first
+      fedora_ark7 = fedora_ark6.scan(/\w/)
+      fedora_ark8 = ""
+      ark_cnt = 0
+      fedora_ark7.each do |ark_l|
+        fedora_ark8 += "/" if ark_cnt.modulo(2).zero?
+        fedora_ark8 += ark_l
+        ark_cnt += 1
       end
-      fedoraArk8 += "/"
-      fedoraArk9 = fedoraArk8 + fedoraArk5
-      fedoraArk10 = fedoraArk9.sub("/zz/","/")
-  
+      fedora_ark8 += "/"
+      fedora_ark9 = fedora_ark8 + fedora_ark5
+      fedora_ark10 = fedora_ark9.sub("/zz/", "/")
+
       # build Fedora URI and remove tombstone if present
       url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}"
-      fedoraArk11 = url + fedoraArk10
-      uri = URI(fedoraArk11)
-      fedoraResp = Net::HTTP.get_response(uri)
-  
-      if fedoraResp.body["ombstone"]
-        fedoraArk11 = fedoraArk11 + "/fcr:tombstone"
-        uri = URI(fedoraArk11)
+      fedora_ark11 = url + fedora_ark10
+      uri = URI(fedora_ark11)
+      fedora_resp = Net::HTTP.get_response(uri)
+
+      if fedora_resp.body["ombstone"]
+        fedora_ark11 += "/fcr:tombstone"
+        uri = URI(fedora_ark11)
         http = Net::HTTP.new(uri.host, uri.port)
         req = Net::HTTP::Delete.new(uri.path)
         req.basic_auth ActiveFedora.config.credentials[:user], ActiveFedora.config.credentials[:password]
         http.request(req)
-        tombstoneMsgAry = Array.new(1, "tombstone removed")
-        @row.error_messages = tombstoneMsgAry
+        tombstone_msg_ary = Array.new(1, "tombstone removed")
+        @row.error_messages = tombstone_msg_ary
       end
     end
 

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -12,44 +12,6 @@ class CsvRowImportJob < ActiveJob::Base
 
     @metadata = JSON.parse(@row.metadata)
 
-###    unless @metadata["Item ARK"] == ""
-###      # build the backwards ark to query Fedora
-###      fedora_ark2 = @metadata["Item ARK"]
-###      fedora_ark3 = fedora_ark2.sub("ark:/", "")
-###      fedora_ark4 = fedora_ark3.sub("/", "-")
-###      fedora_ark5 = fedora_ark4.reverse
-###      fedora_ark6a = fedora_ark5.split("-")
-###      fedora_ark6 = fedora_ark6a.first
-###      fedora_ark7 = fedora_ark6.scan(/\w/)
-###      fedora_ark8 = ""
-###      ark_cnt = 0
-###      fedora_ark7.each do |ark_l|
-###        fedora_ark8 += "/" if ark_cnt.modulo(2).zero?
-###        fedora_ark8 += ark_l
-###        ark_cnt += 1
-###      end
-###      fedora_ark8 += "/"
-###      fedora_ark9 = fedora_ark8 + fedora_ark5
-###      fedora_ark10 = fedora_ark9.sub("/zz/", "/")
-###
-###      # build Fedora URI and remove tombstone if present
-###      url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}"
-###      fedora_ark11 = url + fedora_ark10
-###      uri = URI(fedora_ark11)
-###      fedora_resp = Net::HTTP.get_response(uri)
-###
-###      if fedora_resp.body["ombstone"]
-###        fedora_ark11 += "/fcr:tombstone"
-###        uri = URI(fedora_ark11)
-###        http = Net::HTTP.new(uri.host, uri.port)
-###        req = Net::HTTP::Delete.new(uri.path)
-###        req.basic_auth ActiveFedora.config.credentials[:user], ActiveFedora.config.credentials[:password]
-###        http.request(req)
-###        tombstone_msg_ary = Array.new(1, "tombstone removed")
-###        @row.error_messages = tombstone_msg_ary
-###      end
-###    end
-
     @row.status = @metadata["Object Type"].include?("Page") ? 'not ingested' : 'in progress'
     @metadata = @metadata.merge(row_id: @row_id)
     @csv_import = CsvImport.find(@row.csv_import_id)
@@ -63,7 +25,6 @@ class CsvRowImportJob < ActiveJob::Base
                         end
 
     selected_importer.import(record: record) unless @metadata["Object Type"].include?("Page")
-    
     @row.status = if ['Page', 'ChildWork'].include?(record.mapper.object_type)
                     if @metadata["Object Type"].include?("Page")
                       "not ingested"

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -11,6 +11,45 @@ class CsvRowImportJob < ActiveJob::Base
     @row.ingest_record_start_time = Time.current
 
     @metadata = JSON.parse(@row.metadata)
+
+    # build the backwards ark to query Fedora
+    fedoraArk2 = @metadata["Item ARK"]
+    fedoraArk3 = fedoraArk2.sub("ark:/","")
+    fedoraArk4 = fedoraArk3.sub("/","-")
+    fedoraArk5 = fedoraArk4.reverse
+    fedoraArk6a = fedoraArk5.split("-")
+    fedoraArk6 = fedoraArk6a.first()
+    fedoraArk7 = fedoraArk6.scan /\w/
+    fedoraArk8 = ""
+    arkCnt = 0
+    fedoraArk7.each do |arkL|
+      if arkCnt.modulo(2) == 0
+        fedoraArk8 += "/"
+      end
+      fedoraArk8 += arkL
+      arkCnt += 1
+    end
+    fedoraArk8 += "/"
+    fedoraArk9 = fedoraArk8 + fedoraArk5
+    fedoraArk10 = fedoraArk9.sub("/zz/","/")
+
+    # build Fedora URI and remove tombstone if present
+    url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}"
+    fedoraArk11 = url + fedoraArk10
+    uri = URI(fedoraArk11)
+    fedoraResp = Net::HTTP.get_response(uri)
+
+    if fedoraResp.body["ombstone"]
+      fedoraArk11 = fedoraArk11 + "/fcr:tombstone"
+      uri = URI(fedoraArk11)
+      http = Net::HTTP.new(uri.host, uri.port)
+      req = Net::HTTP::Delete.new(uri.path)
+      req.basic_auth ActiveFedora.config.credentials[:user], ActiveFedora.config.credentials[:password]
+      http.request(req)
+      tombstoneMsgAry = Array.new(1, "tombstone removed")
+      @row.error_messages = tombstoneMsgAry
+    end
+
     @row.status = @metadata["Object Type"].include?("Page") ? 'not ingested' : 'in progress'
     @metadata = @metadata.merge(row_id: @row_id)
     @csv_import = CsvImport.find(@row.csv_import_id)

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -11,7 +11,6 @@ class CsvRowImportJob < ActiveJob::Base
     @row.ingest_record_start_time = Time.current
 
     @metadata = JSON.parse(@row.metadata)
-
     @row.status = @metadata["Object Type"].include?("Page") ? 'not ingested' : 'in progress'
     @metadata = @metadata.merge(row_id: @row_id)
     @csv_import = CsvImport.find(@row.csv_import_id)

--- a/app/jobs/csv_row_import_job.rb
+++ b/app/jobs/csv_row_import_job.rb
@@ -12,43 +12,43 @@ class CsvRowImportJob < ActiveJob::Base
 
     @metadata = JSON.parse(@row.metadata)
 
-    unless @metadata["Item ARK"] == ""
-      # build the backwards ark to query Fedora
-      fedora_ark2 = @metadata["Item ARK"]
-      fedora_ark3 = fedora_ark2.sub("ark:/", "")
-      fedora_ark4 = fedora_ark3.sub("/", "-")
-      fedora_ark5 = fedora_ark4.reverse
-      fedora_ark6a = fedora_ark5.split("-")
-      fedora_ark6 = fedora_ark6a.first
-      fedora_ark7 = fedora_ark6.scan(/\w/)
-      fedora_ark8 = ""
-      ark_cnt = 0
-      fedora_ark7.each do |ark_l|
-        fedora_ark8 += "/" if ark_cnt.modulo(2).zero?
-        fedora_ark8 += ark_l
-        ark_cnt += 1
-      end
-      fedora_ark8 += "/"
-      fedora_ark9 = fedora_ark8 + fedora_ark5
-      fedora_ark10 = fedora_ark9.sub("/zz/", "/")
-
-      # build Fedora URI and remove tombstone if present
-      url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}"
-      fedora_ark11 = url + fedora_ark10
-      uri = URI(fedora_ark11)
-      fedora_resp = Net::HTTP.get_response(uri)
-
-      if fedora_resp.body["ombstone"]
-        fedora_ark11 += "/fcr:tombstone"
-        uri = URI(fedora_ark11)
-        http = Net::HTTP.new(uri.host, uri.port)
-        req = Net::HTTP::Delete.new(uri.path)
-        req.basic_auth ActiveFedora.config.credentials[:user], ActiveFedora.config.credentials[:password]
-        http.request(req)
-        tombstone_msg_ary = Array.new(1, "tombstone removed")
-        @row.error_messages = tombstone_msg_ary
-      end
-    end
+###    unless @metadata["Item ARK"] == ""
+###      # build the backwards ark to query Fedora
+###      fedora_ark2 = @metadata["Item ARK"]
+###      fedora_ark3 = fedora_ark2.sub("ark:/", "")
+###      fedora_ark4 = fedora_ark3.sub("/", "-")
+###      fedora_ark5 = fedora_ark4.reverse
+###      fedora_ark6a = fedora_ark5.split("-")
+###      fedora_ark6 = fedora_ark6a.first
+###      fedora_ark7 = fedora_ark6.scan(/\w/)
+###      fedora_ark8 = ""
+###      ark_cnt = 0
+###      fedora_ark7.each do |ark_l|
+###        fedora_ark8 += "/" if ark_cnt.modulo(2).zero?
+###        fedora_ark8 += ark_l
+###        ark_cnt += 1
+###      end
+###      fedora_ark8 += "/"
+###      fedora_ark9 = fedora_ark8 + fedora_ark5
+###      fedora_ark10 = fedora_ark9.sub("/zz/", "/")
+###
+###      # build Fedora URI and remove tombstone if present
+###      url = "#{ActiveFedora.config.credentials[:url]}#{ActiveFedora.config.credentials[:base_path]}"
+###      fedora_ark11 = url + fedora_ark10
+###      uri = URI(fedora_ark11)
+###      fedora_resp = Net::HTTP.get_response(uri)
+###
+###      if fedora_resp.body["ombstone"]
+###        fedora_ark11 += "/fcr:tombstone"
+###        uri = URI(fedora_ark11)
+###        http = Net::HTTP.new(uri.host, uri.port)
+###        req = Net::HTTP::Delete.new(uri.path)
+###        req.basic_auth ActiveFedora.config.credentials[:user], ActiveFedora.config.credentials[:password]
+###        http.request(req)
+###        tombstone_msg_ary = Array.new(1, "tombstone removed")
+###        @row.error_messages = tombstone_msg_ary
+###      end
+###    end
 
     @row.status = @metadata["Object Type"].include?("Page") ? 'not ingested' : 'in progress'
     @metadata = @metadata.merge(row_id: @row_id)
@@ -63,6 +63,7 @@ class CsvRowImportJob < ActiveJob::Base
                         end
 
     selected_importer.import(record: record) unless @metadata["Object Type"].include?("Page")
+    
     @row.status = if ['Page', 'ChildWork'].include?(record.mapper.object_type)
                     if @metadata["Object Type"].include?("Page")
                       "not ingested"


### PR DESCRIPTION
Connected to [CAL-949](https://jira.library.ucla.edu/browse/CAL-949) and [CAL-956](https://jira.library.ucla.edu/browse/CAL-956)

---

Automatically ingest CSVs that have Collections and/or Works with tombstones instead of contacting the DIIT Apps team for manual intervention.

---

**Acceptance Criteria:**


- [x] Californica catches errors from Fedora when a tombstoned item is reingested (LGPGone error)
- [x] The ingest code deletes the tombstone and recreates the object

**Files**
`app/importers/actor_record_importer.rb`
`app/importers/collection_record_importer.rb`

**Verified**
Several collection and/or works were ingested, deleted and re-ingested to verify satisfactory operation in the presence of tombstones. The following behavior is encountered when re-ingesting:

_Collection_

Re-ingesting the whole collection (collection and all works) is required so that the system can associate the works with the re-ingested collection.

- After a collection is deleted, the works associated with that collection remain in the system and are discoverable using search.
- To remove a work completely, from the system, click on the delete button while viewing the work.

_Works_

- Works may be deleted by clicking on the delete button using the Californica gui.
- Deleting a work removes it completely from the system.
- The Apps team in DIIT can batch delete of many (or all) works of a collection by processing the original csv file used to create the collection.

Details: [CAL-949](https://jira.library.ucla.edu/browse/CAL-949).
