### PR TITLE
URS 955: Ursus: add "Repository" field to browse facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -511,6 +511,14 @@ class CatalogController < ApplicationController
       }
     end
 
+    config.add_search_field('repository') do |field|
+      solr_name = solr_name('repository', :stored_sortable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc

--- a/app/models/ucla_metadata.rb
+++ b/app/models/ucla_metadata.rb
@@ -197,7 +197,7 @@ module UclaMetadata
 
     # Find This Item
     property :repository, predicate: ::RDF::Vocab::MODS.locationCopySublocation do |index|
-      index.as :stored_searchable, :facetable
+      index.as :displayable, :facetable
     end
 
     property :local_identifier, predicate: ::RDF::Vocab::Identifiers.local do |index|

--- a/app/models/ucla_metadata.rb
+++ b/app/models/ucla_metadata.rb
@@ -274,6 +274,10 @@ module UclaMetadata
     property :tagline, predicate: ::RDF::URI.intern('http://iflastandards.info/ns/fr/frbr/frbrer/P3081'), multiple: false do |index|
       index.as :stored_sortable
     end
+
+    property :repository, predicate: ::RDF::URI.intern('https://bib.schema.org/Collection') do |index|
+      index.as :displayable, :facetable
+    end
   end
 end
 

--- a/app/models/ucla_metadata.rb
+++ b/app/models/ucla_metadata.rb
@@ -197,7 +197,7 @@ module UclaMetadata
 
     # Find This Item
     property :repository, predicate: ::RDF::Vocab::MODS.locationCopySublocation do |index|
-      index.as :stored_searchable
+      index.as :stored_searchable, :facetable
     end
 
     property :local_identifier, predicate: ::RDF::Vocab::Identifiers.local do |index|
@@ -273,10 +273,6 @@ module UclaMetadata
 
     property :tagline, predicate: ::RDF::URI.intern('http://iflastandards.info/ns/fr/frbr/frbrer/P3081'), multiple: false do |index|
       index.as :stored_sortable
-    end
-
-    property :repository, predicate: ::RDF::URI.intern('https://bib.schema.org/Collection') do |index|
-      index.as :displayable, :facetable
     end
   end
 end

--- a/app/models/ucla_metadata.rb
+++ b/app/models/ucla_metadata.rb
@@ -197,7 +197,7 @@ module UclaMetadata
 
     # Find This Item
     property :repository, predicate: ::RDF::Vocab::MODS.locationCopySublocation do |index|
-      index.as :displayable, :facetable
+      index.as :stored_searchable, :facetable
     end
 
     property :local_identifier, predicate: ::RDF::Vocab::Identifiers.local do |index|

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -55,7 +55,7 @@
 <%= presenter.attribute_to_html(:provenance, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link, html_dl: true) %>
-<%= presenter.attribute_to_html(:repository, html_dl: true) %>
+<%= presenter.attribute_to_html(:repository, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:representative_image, html_dl: true) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :resource_type, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_country, html_dl: true) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -12,6 +12,7 @@ en:
           language_sim: Language
           publisher_sim: Publisher
           subject_sim: Subject
+          repository_sim: Repository
         index:
           based_near_tesim: Based Near
           contributor_tesim: Contributor

--- a/spec/system/import_and_show_work_spec.rb
+++ b/spec/system/import_and_show_work_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Import and Display a Work', :clean, type: :system, inline_jobs: 
 
     # displays expected facets
     facet_headings = page.all(:css, 'h3.facet-field-heading').to_a.map(&:text)
-    expect(facet_headings).to contain_exactly("Subject", "Creator", "Resource Type", "Genre", "Names", "Location", "Normalized Date", "Extent", "Medium", "Dimensions", "Language", "Collection", "Subject geographic", "Subject temporal")
+    expect(facet_headings).to contain_exactly("Subject", "Creator", "Resource Type", "Genre", "Names", "Location", "Normalized Date", "Extent", "Medium", "Dimensions", "Language", "Collection", "Subject geographic", "Subject temporal", "Repository")
 
     # # iiif manifest was cached
     # filename = Rails.root.join('tmp', work.date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + work.id)


### PR DESCRIPTION
Connected to [URS-955](https://jira.library.ucla.edu/secure/RapidBoard.jspa?rapidView=131&view=detail&selectedIssue=URS-955)
Acceptance criteria:

- [x] There is a new Browse facet on the Digital Collections site with the label "Repository" that is populated by the Repository field