### PR TITLE
quick fix for thumbnail logic

### DIFF
--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -32,10 +32,11 @@ class CollectionIndexer < Hyrax::CollectionWithBasicMetadataIndexer
 
   def thumbnail_url
     thumbnail = object.thumbnail_link || thumbnail_from_access_copy
-    if thumbnail.to_s.include?('/iiif/2/')
-      "#{thumbnail}/full/!200,200/0/default.jpg"
-    elsif ['.svg', '.png', '.jpg'].include? File.extname(thumbnail.to_s)
+    case thumbnail
+    when /\.(svg)|(png)|(jpg)$/
       thumbnail
+    when /\/iiif\/2\/[^\/]+$/
+      "#{thumbnail}/full/!200,200/0/default.jpg"
     else
       return nil
     end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -89,10 +89,11 @@ class WorkIndexer < Hyrax::WorkIndexer
 
   def thumbnail_url
     thumbnail = object.thumbnail_link || thumbnail_from_access_copy
-    if thumbnail.to_s.include?('/iiif/2/')
-      "#{thumbnail}/full/!200,200/0/default.jpg"
-    elsif ['.svg', '.png', '.jpg'].include? File.extname(thumbnail.to_s)
+    case thumbnail
+    when /\.(svg)|(png)|(jpg)$/
       thumbnail
+    when /\/iiif\/2\/[^\/]+$/
+      "#{thumbnail}/full/!200,200/0/default.jpg"
     else
       return nil
     end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe ::CollectionIndexer do
       it 'adds iiif parameters' do
         expect(solr_document['thumbnail_url_ss']).to eq 'https://fake.url/iiif/2/id/full/!200,200/0/default.jpg'
       end
+
+      context 'when it already includes iiif parameters' do
+        let(:thumbnail_link) { 'https://fake.url/iiif/2/id/full/!200,200/0/default.jpg' }
+
+        it 'does not add them again' do
+          expect(solr_document['thumbnail_url_ss']).to eq 'https://fake.url/iiif/2/id/full/!200,200/0/default.jpg'
+        end
+      end
+
+      context 'when it doesn\'t match the expected format' do
+        let(:thumbnail_link) { 'https://fake.url/iiif/2/id/full/!200,200/' }
+
+        it 'returns nil' do
+          expect(solr_document['thumbnail_url_ss']).to eq nil
+        end
+      end
     end
 
     context 'when thumbnail_link is an image url' do

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -393,6 +393,22 @@ RSpec.describe WorkIndexer do
       it 'adds iiif parameters' do
         expect(solr_document['thumbnail_url_ss']).to eq 'https://fake.url/iiif/2/id/full/!200,200/0/default.jpg'
       end
+
+      context 'when it already includes iiif parameters' do
+        let(:thumbnail_link) { 'https://fake.url/iiif/2/id/full/!200,200/0/default.jpg' }
+
+        it 'does not add them again' do
+          expect(solr_document['thumbnail_url_ss']).to eq 'https://fake.url/iiif/2/id/full/!200,200/0/default.jpg'
+        end
+      end
+
+      context 'when it doesn\'t match the expected format' do
+        let(:thumbnail_link) { 'https://fake.url/iiif/2/id/full/!200,200/' }
+
+        it 'returns nil' do
+          expect(solr_document['thumbnail_url_ss']).to eq nil
+        end
+      end
     end
 
     context 'when thumbnail_link is an image url' do


### PR DESCRIPTION
updates thumbnail indexing logic to ensure that:
- a fully formed IIIF url (with parameters) is passed as is, without spurious parameters added
- if the IIIF resource is improperly formatted, we don't index it (Ursus will use the default icon)