### PR TITLE
fork nulib/fcrepo4 docker image to uclalibrary/fcrepo4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     working_dir: /californica
 
   fedora:
-    image: nulib/fcrepo4:4.7.5
+    image: uclalibrary/fcrepo4:4.7.5
     ports:
       - '127.0.0.1:8984:8080'
     volumes:
@@ -62,7 +62,7 @@ services:
       JAVA_OPTIONS: '-Xmx512m'
 
   fedora_test:
-    image: nulib/fcrepo4:4.7.5
+    image: uclalibrary/fcrepo4:4.7.5
     ports:
       - '127.0.0.1:8986:8080'
     environment:


### PR DESCRIPTION
Northwestern University library removed their fcrepo image from dockerhub, so we've pushed an old copy into our own organization.