### PR TITLE
fix: APPS-2357_wrong-image-associated-with-uploaded-metadata

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -155,7 +155,7 @@ class SolrDocument
   end
 
   def iiif_manifest_url
-    self[:iiif_manifest_url_ssi] || "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00090p17/manifest"
+    self[:iiif_manifest_url_ssi] || ""
   end
 
   def iiif_range

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SolrDocument do
 
     context 'when no external manifest URL is stored' do
       it 'links to the local manifest builder' do
-        expect(solr_document.iiif_manifest_url).to eq "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00090p17/manifest"
+        expect(solr_document.iiif_manifest_url).to eq ""
       end
     end
   end


### PR DESCRIPTION
Connected to [APPS-2357](https://jira.library.ucla.edu/browse/APPS-2357)

CSVs with no content invoke the Universal Viewer but are displayed with no image.