### PR TITLE
fix: add work count and childworkcount to rollbar logs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,7 @@ Metrics/ClassLength:
     - app/uploaders/csv_manifest_validator.rb
     - app/indexers/work_indexer.rb
     - app/presenters/hyrax/californica_collection_presenter.rb
+    - app/lib/californica/deleter.rb
 
 Metrics/BlockLength:
   Enabled: true

--- a/app/lib/californica/deleter.rb
+++ b/app/lib/californica/deleter.rb
@@ -22,6 +22,7 @@ module Californica
     def delete_collection_with_works(of_type: nil)
       log('In delete_collection_with_works start.')
       works = work_id_list
+      log("Number of works in collection #{id}: #{works.count}") # Log the number of works
       all_works_deleted = works.empty? || delete_works(of_type: of_type)
       if all_works_deleted && (of_type.nil? || record.is_a?(of_type))
         delete
@@ -44,6 +45,7 @@ module Californica
     def delete_with_children(of_type: nil)
       log('In delete_with_children start.')
       children = record&.member_ids
+      log("Number of child works for work #{id}: #{children&.count || 0}") # Log the number of child works
       all_children_deleted = children.nil? || children.empty? || delete_children(of_type: of_type)
       if all_children_deleted && (of_type.nil? || record.is_a?(of_type))
         delete

--- a/app/lib/californica/deleter.rb
+++ b/app/lib/californica/deleter.rb
@@ -44,10 +44,7 @@ module Californica
     # Modified to ensure all works are deleted before deleting the collection
     def delete_with_children(of_type: nil)
       log('In delete_with_children start.')
-      children = record&.member_ids
-      log("Number of child works for work #{id}: #{children&.count || 0}") # Log the number of child works
-      all_children_deleted = children.nil? || children.empty? || delete_children(of_type: of_type)
-      if all_children_deleted && (of_type.nil? || record.is_a?(of_type))
+      if can_delete_with_children?(of_type)
         delete
         true
       else
@@ -65,6 +62,19 @@ module Californica
     end
 
     private
+
+      def can_delete_with_children?(of_type)
+        children_deleted_or_none?(of_type) && deletion_type_matches?(of_type)
+      end
+
+      def children_deleted_or_none?(of_type)
+        children = record&.member_ids
+        children.nil? || children.empty? || delete_children(of_type: of_type)
+      end
+
+      def deletion_type_matches?(of_type)
+        of_type.nil? || record.is_a?(of_type)
+      end
 
       def destroy_and_eradicate
         start_time = Time.current

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -2,7 +2,13 @@
 
 namespace :californica do
   task delete_work: [:environment] do
-    Californica::Deleter.new(id: ENV.fetch('DELETE_WORK_ID')).delete_with_children
+    begin
+      deletion_successful = Californica::Deleter.new(id: ENV.fetch('DELETE_WORK_ID')).delete_with_children
+      puts deletion_successful ? 'Deletion completed successfully!' : 'Deletion skipped for some items.'
+    rescue => e
+      puts "An error occurred: #{e.message}"
+    end
+    
     puts('Done!')
   end
 

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -8,7 +8,7 @@ namespace :californica do
     rescue => e
       puts "An error occurred: #{e.message}"
     end
-    
+
     puts('Done!')
   end
 


### PR DESCRIPTION
Connected to https://uclalibrary.atlassian.net/browse/APPS-2387