### PR TITLE
patch: updates to reindex job

### DIFF
--- a/app/jobs/reindex_everything_from_solr_job.rb
+++ b/app/jobs/reindex_everything_from_solr_job.rb
@@ -6,10 +6,10 @@ class ReindexEverythingFromSolrJob < ApplicationJob
 
   queue_as Hyrax.config.ingest_queue_name
 
-  def expiration
-    @expiration ||= 60 * 60 * 24 * 365 # 1 year
-  end
-
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
   def perform(cutoff_datetime: Time.zone.now.to_s)
     start_time = Time.zone.now.localtime
     cutoff_datetime = Time.zone.parse(cutoff_datetime)
@@ -21,7 +21,21 @@ class ReindexEverythingFromSolrJob < ApplicationJob
       total @total_n_items
 
       next_batch_ids(cutoff_datetime, 10).each_with_index do |id, i|
-        at @total_n_items - @n_remaining + i, "#{@total_n_items - @n_remaining + i} / #{@total_n_items}"
+        @initial_n_remaining ||= @n_remaining
+
+        msg = "#{@total_n_items - @n_remaining + i} / #{@total_n_items}"
+        actual_n_remaining = @n_remaining - i
+        if actual_n_remaining < @initial_n_remaining
+          rate = (Time.zone.now.localtime - start_time) / (@initial_n_remaining - actual_n_remaining)
+          seconds_remaining = (@n_remaining - i) * rate
+          msg += " (#{rate.round(1)}s per item,  "
+          msg += (seconds_remaining / 60 / 60 / 24).floor.to_s + "d " if seconds_remaining > 60 * 60 * 24
+          msg += (seconds_remaining / 60 / 60 % 24).floor.to_s + "h " if seconds_remaining > 60 * 60
+          msg += (seconds_remaining / 60 % 60).floor.to_s + "m " if seconds_remaining > 60
+          msg += (seconds_remaining % 60).round.to_s + "s " if seconds_remaining
+          msg += "remaining)"
+        end
+        at @total_n_items - @n_remaining + i, msg
         reindex_item(id)
       end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,15 +2,17 @@
 require 'sidekiq'
 require 'sidekiq-status'
 
+REDIS_EXPIRATION = 31.days
+
 Sidekiq.configure_client do |config|
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_client_middleware config, expiration: REDIS_EXPIRATION
 end
 
 Sidekiq.configure_server do |config|
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_server_middleware config, expiration: REDIS_EXPIRATION
 
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_client_middleware config, expiration: REDIS_EXPIRATION
 end

--- a/lib/tasks/reindex.rake
+++ b/lib/tasks/reindex.rake
@@ -6,8 +6,8 @@
 # that already exist.  So, for example, it can't be
 # used to repopulate the solr records after a clean.
 desc 'Re-index solr records for californica works & collections'
-task :reindex, [:arg1] => :environment do |t, args|
-  cutoff_timestamp = args[:arg1] || (Time.zone.now.to_s)
+task :reindex, [:arg1] => :environment do |_t, args|
+  cutoff_timestamp = args[:arg1] || Time.zone.now.to_s
   if Time.zone.parse(cutoff_timestamp)
     ReindexEverythingFromSolrJob.perform_later cutoff_datetime: cutoff_timestamp
   else


### PR DESCRIPTION
- allows specifying a cutoff date other than Time.zone.now() when starting job, to resume a previous reindex
- less collection reindexing?
- consistent expiration of sidekiq status metadata in redis
- estimate time remaining